### PR TITLE
Drop generate_data function import

### DIFF
--- a/src/instructlab/sdg/__init__.py
+++ b/src/instructlab/sdg/__init__.py
@@ -1,3 +1,0 @@
-# First party
-# First Party
-from instructlab.sdg.generate_data import generate_data


### PR DESCRIPTION
This is confusing some tests in the CLI repo and is not necessary.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
