### PR TITLE
Fix rename of a module in instructlab

### DIFF
--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -15,7 +15,7 @@ import time
 
 # Third Party
 # instructlab - All of these need to go away (other than sdg) - issue #6
-from instructlab.config import get_model_family
+from instructlab.configuration import get_model_family
 from instructlab.utils import (
     chunk_document,
     max_seed_example_tokens,


### PR DESCRIPTION
instructlab.config got renamed to instructlab.configuration

Signed-off-by: Russell Bryant <rbryant@redhat.com>
