### PR TITLE
requirements.txt: Move instructlab to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# TODO: Uncomment below line once requirements.txt is created
 -r requirements.txt
 
+# TODO: remove 'instructlab' once https://github.com/instructlab/sdg/issues/6 is resolved
+instructlab>=0.17.0
 pre-commit>=3.0.4,<4.0
 pylint>=2.16.2,<4.0
 pylint-pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,3 @@ jinja2
 openai>=1.13.3,<2.0.0
 rouge_score
 tqdm>=4.66.2,<5.0.0
-# TODO: remove 'instructlab' once https://github.com/instructlab/sdg/issues/6 is resolved
-instructlab>=0.17.0


### PR DESCRIPTION

70335a1 requirements.txt: instructlab to requirements-dev.txt

commit 70335a140f9036a135fa228165c4964695a37912
Author: Russell Bryant <rbryant@redhat.com>
Date:   Tue Jun 18 21:26:12 2024 -0400

    requirements.txt: instructlab to requirements-dev.txt
    
    This is still a dependency, but it's causing some problems in
    `instructlab` repo CI. A released version of instructlab gets
    installed first because of this entry, then it has to be uninstalled
    before the development version can be installed.
    
    The currently released version of `instructlab` still has schema
    embedded. The next release (and current `main`) uses the
    `instructlab-schema` package. Moving from one to the other in tox
    is breaking the schema package.
    
    By moving it, it will still be installed for local repo testing
    purposes.
    
    This should solve the CI failures seen here:
    https://github.com/instructlab/instructlab/pull/1244
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
