### PR TITLE
Restrict version of tenacity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,9 @@ jinja2
 langchain-text-splitters
 openai>=1.13.3,<2.0.0
 rouge_score
+# Note: this dependency goes along with langchain-text-splitters and mayt be
+#       removed once that one is removed.
+# do not use 8.4.0 due to a bug in the library
+# https://github.com/instructlab/instructlab/issues/1389
+tenacity>=8.3.0,!=8.4.0
 tqdm>=4.66.2,<5.0.0


### PR DESCRIPTION
A bug was discovered when the related code was in the CLI repo. We
need to restrict the version of `tenacity` pulled in by
`langhchain-text-splitters`.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
