### PR TITLE
github: Automate some labels with mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,77 @@
+pull_request_rules:
+
+- name: label-cicd
+  description: Automatically apply CI/CD label
+  conditions:
+    - or:
+      - files=.github/mergify.yml
+      - files=.github/workflows/**/*
+      - files=.pylintrc
+      - files=.spellcheck-en-custom.txt
+      - files=.spellcheck.yml
+      - files=tox.ini
+      - files=.markdownlint-cli2.yaml
+  actions:
+    label:
+      add:
+        - CI/CD
+
+- name: label-documentation
+  description: Automatically apply documentation label
+  conditions:
+    - or:
+      - files~=.*\.md
+      - files~=docs/.*
+  actions:
+    label:
+      add:
+        - documentation
+
+- name: label-testing
+  description: Automatically apply testing label
+  conditions:
+    - or:
+      - files~=tests/.*
+      - files=tox.ini
+  actions:
+    label:
+      add:
+        - testing
+
+- name: ping author on conflicts and add 'needs-rebase' label
+  conditions:
+      - conflict
+      - -closed
+  actions:
+    label:
+      add:
+        - needs-rebase
+    comment:
+      message: |
+       This pull request has merge conflicts that must be resolved before it can be
+       merged. @{{author}} please rebase it. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
+
+- name: remove 'needs-rebase' label when conflict is resolved
+  conditions:
+      - -conflict
+      - -closed
+  actions:
+    label:
+      remove:
+        - needs-rebase
+
+- name: Apply ci-failure label if any CI checks have failed
+  conditions:
+      - "#check-failure>0"
+  actions:
+    label:
+      add:
+        - ci-failure
+
+- name: Remove ci-failure label if no failures are present
+  conditions:
+      - "#check-failure=0"
+  actions:
+    label:
+      remove:
+        - ci-failure


### PR DESCRIPTION
This introduces some mergify configuration to automate setting labels
on PRs. This does NOT turn on PR merge automation.

- `CI/CD` for CI config changes
- `documentation` for markdown file changes
- `testing` for test code
- `ci-failure` for PRs that failed CI
- `needs-rebase` for PRs in conflict

Signed-off-by: Russell Bryant <rbryant@redhat.com>
