### PR TITLE
e2e: Fix permissions error

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           sudo apt-get install -y cuda-toolkit git cmake build-essential virtualenv
           nvidia-smi
-          ls -l /dev/nvidia*
+          sudo ls -l /dev/nvidia*
 
       - name: Setup Python 3.11
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0


### PR DESCRIPTION
Something changed in the underlying image where this command now
caused a failure on a permissions error. The output was helpful at
some point during debugging so I'm leaving it in place, but running it
with sudo to avoid the permissions error.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
