### PR TITLE
Fix prompt file paths for an installed library

### DIFF
--- a/src/instructlab/sdg/default_flows.py
+++ b/src/instructlab/sdg/default_flows.py
@@ -36,6 +36,7 @@ class Flow(ABC):
         self.model_id = model_id
         self.num_iters = num_iters
         self.batched = batched
+        self.sdg_base = resources.files(__package__)
 
     @abstractmethod
     def get_flow(self) -> list:
@@ -76,9 +77,8 @@ class _SimpleFlow(Flow):
 class SimpleKnowledgeFlow(_SimpleFlow):
     def get_flow(self) -> list:
         flow = super().get_flow()
-        sdg_base = resources.files(__package__)
         flow[0]["block_config"]["block_kwargs"]["config_path"] = os.path.join(
-            sdg_base, "configs/knowledge/simple_generate_qa.yaml"
+            self.sdg_base, "configs/knowledge/simple_generate_qa.yaml"
         )
         flow[0]["block_config"]["block_kwargs"]["block_name"] = "gen_knowledge"
         flow[0]["block_config"]["block_name"] = "gen_knowledge"
@@ -88,9 +88,8 @@ class SimpleKnowledgeFlow(_SimpleFlow):
 class SimpleFreeformSkillFlow(_SimpleFlow):
     def get_flow(self) -> list:
         flow = super().get_flow()
-        sdg_base = resources.files(__package__)
         flow[0]["block_config"]["block_kwargs"]["config_path"] = os.path.join(
-            sdg_base, "configs/skills/simple_generate_qa_freeform.yaml"
+            self.sdg_base, "configs/skills/simple_generate_qa_freeform.yaml"
         )
         flow[0]["block_config"]["block_kwargs"]["block_name"] = "gen_skill_freeform"
         flow[0]["block_config"]["block_name"] = "gen_skill_freeform"
@@ -100,9 +99,8 @@ class SimpleFreeformSkillFlow(_SimpleFlow):
 class SimpleGroundedSkillFlow(_SimpleFlow):
     def get_flow(self) -> list:
         flow = super().get_flow()
-        sdg_base = resources.files(__package__)
         flow[0]["block_config"]["block_kwargs"]["config_path"] = os.path.join(
-            sdg_base, "configs/skills/simple_generate_qa_grounded.yaml"
+            self.sdg_base, "configs/skills/simple_generate_qa_grounded.yaml"
         )
         flow[0]["block_config"]["block_kwargs"]["block_name"] = "gen_skill_grounded"
         flow[0]["block_config"]["block_name"] = "gen_skill_grounded"
@@ -111,14 +109,14 @@ class SimpleGroundedSkillFlow(_SimpleFlow):
 
 class MMLUBenchFlow(Flow):
     def get_flow(self) -> list:
-        sdg_base = resources.files(__package__)
+        self.sdg_base = resources.files(__package__)
         return [
             {
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "gen_mmlu_knowledge",
                     "config_path": os.path.join(
-                        sdg_base, "configs/knowledge/mcq_generation.yaml"
+                        self.sdg_base, "configs/knowledge/mcq_generation.yaml"
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
@@ -140,14 +138,13 @@ class MMLUBenchFlow(Flow):
 
 class SynthKnowledgeFlow(Flow):
     def get_flow(self) -> list:
-        sdg_base = resources.files(__package__)
         return [
             {
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "gen_knowledge",
                     "config_path": os.path.join(
-                        sdg_base, "configs/knowledge/generate_questions_responses.yaml"
+                        self.sdg_base, "configs/knowledge/generate_questions_responses.yaml"
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
@@ -173,7 +170,7 @@ class SynthKnowledgeFlow(Flow):
                 "block_config": {
                     "block_name": "eval_faithfulness_qa_pair",
                     "config_path": os.path.join(
-                        sdg_base, "configs/knowledge/evaluate_faithfulness.yaml"
+                        self.sdg_base, "configs/knowledge/evaluate_faithfulness.yaml"
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
@@ -206,7 +203,7 @@ class SynthKnowledgeFlow(Flow):
                 "block_config": {
                     "block_name": "eval_relevancy_qa_pair",
                     "config_path": os.path.join(
-                        sdg_base, "configs/knowledge/evaluate_relevancy.yaml"
+                        self.sdg_base, "configs/knowledge/evaluate_relevancy.yaml"
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
@@ -240,7 +237,7 @@ class SynthKnowledgeFlow(Flow):
                 "block_config": {
                     "block_name": "eval_verify_question",
                     "config_path": os.path.join(
-                        sdg_base, "configs/knowledge/evaluate_question.yaml"
+                        self.sdg_base, "configs/knowledge/evaluate_question.yaml"
                     ),
                     "client": self.client,
                     "model_id": self.model_id,

--- a/src/instructlab/sdg/default_flows.py
+++ b/src/instructlab/sdg/default_flows.py
@@ -144,7 +144,8 @@ class SynthKnowledgeFlow(Flow):
                 "block_config": {
                     "block_name": "gen_knowledge",
                     "config_path": os.path.join(
-                        self.sdg_base, "configs/knowledge/generate_questions_responses.yaml"
+                        self.sdg_base,
+                        "configs/knowledge/generate_questions_responses.yaml",
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
@@ -276,7 +277,10 @@ class SynthSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "gen_questions",
-                    "config_path": "src/instructlab/sdg/configs/skills/freeform_questions.yaml",
+                    "config_path": os.path.join(
+                        self.sdg_base,
+                        "configs/skills/freeform_questions.yaml",
+                    ),
                     "client": self.client,
                     "model_id": self.model_id,
                     "model_prompt": _get_model_prompt(self.model_family),
@@ -293,7 +297,10 @@ class SynthSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "eval_questions",
-                    "config_path": "src/instructlab/sdg/configs/skills/evaluate_freeform_questions.yaml",
+                    "config_path": os.path.join(
+                        self.sdg_base,
+                        "configs/skills/evaluate_freeform_questions.yaml",
+                    ),
                     "client": self.client,
                     "model_id": self.model_id,
                     "model_prompt": _get_model_prompt(self.model_family),
@@ -322,7 +329,10 @@ class SynthSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "gen_responses",
-                    "config_path": "src/instructlab/sdg/configs/skills/freeform_responses.yaml",
+                    "config_path": os.path.join(
+                        self.sdg_base,
+                        "configs/skills/freeform_responses.yaml",
+                    ),
                     "client": self.client,
                     "model_id": self.model_id,
                     "model_prompt": _get_model_prompt(self.model_family),
@@ -337,7 +347,10 @@ class SynthSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "evaluate_qa_pair",
-                    "config_path": "src/instructlab/sdg/configs/skills/evaluate_freeform_pair.yaml",
+                    "config_path": os.path.join(
+                        self.sdg_base,
+                        "configs/skills/evaluate_freeform_pair.yaml",
+                    ),
                     "client": self.client,
                     "model_id": self.model_id,
                     "model_prompt": _get_model_prompt(self.model_family),
@@ -376,7 +389,10 @@ class SynthGroundedSkillsFlow(Flow):
                     "block_type": LLMBlock,
                     "block_kwargs": {
                         "block_name": "gen_contexts",
-                        "config_path": "src/instructlab/sdg/configs/skills/contexts.yaml",
+                        "config_path": os.path.join(
+                            self.sdg_base,
+                            "configs/skills/contexts.yaml",
+                        ),
                         "client": self.client,
                         "model_id": self.model_id,
                         "model_prompt": _get_model_prompt(self.model_family),
@@ -396,7 +412,10 @@ class SynthGroundedSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "gen_grounded_questions",
-                    "config_path": "src/instructlab/sdg/configs/skills/grounded_questions.yaml",
+                    "config_path": os.path.join(
+                        self.sdg_base,
+                        "configs/skills/grounded_questions.yaml",
+                    ),
                     "client": self.client,
                     "model_id": self.model_id,
                     "model_prompt": _get_model_prompt(self.model_family),
@@ -412,7 +431,10 @@ class SynthGroundedSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "eval_grounded_questions",
-                    "config_path": "src/instructlab/sdg/configs/skills/evaluate_grounded_questions.yaml",
+                    "config_path": os.path.join(
+                        self.sdg_base,
+                        "configs/skills/evaluate_grounded_questions.yaml",
+                    ),
                     "client": self.client,
                     "model_id": self.model_id,
                     "model_prompt": _get_model_prompt(self.model_family),
@@ -442,7 +464,10 @@ class SynthGroundedSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "gen_grounded_responses",
-                    "config_path": "src/instructlab/sdg/configs/skills/grounded_responses.yaml",
+                    "config_path": os.path.join(
+                        self.sdg_base,
+                        "configs/skills/grounded_responses.yaml",
+                    ),
                     "client": self.client,
                     "model_id": self.model_id,
                     "model_prompt": _get_model_prompt(self.model_family),
@@ -457,7 +482,10 @@ class SynthGroundedSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "evaluate_grounded_qa_pair",
-                    "config_path": "src/instructlab/sdg/configs/skills/evaluate_grounded_pair.yaml",
+                    "config_path": os.path.join(
+                        self.sdg_base,
+                        "configs/skills/evaluate_grounded_pair.yaml",
+                    ),
                     "client": self.client,
                     "model_id": self.model_id,
                     "model_prompt": _get_model_prompt(self.model_family),


### PR DESCRIPTION

2debc77 default_flows: Move sdg_base into base Flow class
3e01b18 Fix remaining prompt file paths

commit 2debc7792a3db75ed90ed59eb42678ac0592d32c
Author: Russell Bryant <rbryant@redhat.com>
Date:   Tue Jul 2 16:36:28 2024 -0400

    default_flows: Move sdg_base into base Flow class
    
    Each subclass was calculating the root directory of the python package
    for finding prompt templates that are embedded in the package. Move
    this to the base `Flow` class so we're only doing it in one place.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 3e01b18112fbabd418f028697288366d1c3f8ae5
Author: Russell Bryant <rbryant@redhat.com>
Date:   Tue Jul 2 16:42:21 2024 -0400

    Fix remaining prompt file paths
    
    Special handling is required to find these prompt files from an
    installed version of the instructlab-sdg package. This updates the
    rest of this file to make use of `self.sdg_base` from the base `Flow`
    class which will work from an installed library.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
