### PR TITLE
e2e: Only run one job at a time for a given PR

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,10 @@ on:
       - 'requirements*.txt'
       - '.github/workflows/e2e.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ubuntu-gpu


### PR DESCRIPTION
If you push updates to a PR, currently we're leaving `e2e` jobs for
all past revisions to keep running. If you do a few quick updates,
that ends up wasting a lot of resources.

This change ensures that for a given PR, only one of these jobs runs
at a time. A previous run will get canceled and replaced with one
against the latest version of the PR.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
