### PR TITLE
mergify: Add merge automation

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,5 +1,80 @@
 pull_request_rules:
 
+- name: auto-merge
+  description: automatic merge for main with >= 2 approved reviews, all requested reviews have given feedback, not held, and CI is successful
+  conditions:
+    - "#approved-reviews-by>=2"
+    - "#review-requested=0"
+    - "#changes-requested-reviews-by=0"
+    - or:
+      - base=main
+      - base~=release-.*
+    - label!=hold
+    - label!=do-not-merge
+    - label!=needs-rebase
+    - check-success=DCO
+
+    # If files are changed in .github/, the actionlint check must pass
+    - or:
+      - and:
+        # regex should match the one in .github/workflows/actionlint.yml
+        - files~=.github/workflows/.*\.ya?ml$
+        - check-success=actionlint
+      - -files~=.github/workflows/.*\.ya?ml$
+
+    # e2e workflow
+    - or:
+      - and:
+        - check-success=e2e
+        - or:
+          - files~='.*\.py$'
+          - files~=pyproject.toml$
+          - files~=requirements.*\.txt$
+          - files~=.github/workflows/e2e.yml$
+      - and:
+        - -files~='.*\.py$'
+        - -files~=pyproject.toml$
+        - -files~=requirements.*\.txt$
+        - -files~=.github/workflows/e2e.yml$
+
+    # lint and test must pass if files change that would trigger this job
+    - or:
+      - and:
+        - check-success=lint
+        - check-success=test-workflow-complete
+        - or:
+          # see .github/workflows/lint.yml and test.yml
+          - files~=.*\.py$
+          - files~=pyproject.toml$
+          - files~=requirements.*\.txt$
+          - files~=tox.ini$
+          - files~=scripts/[^/]+\.sh$
+          - files~=.github/.*$
+      - and:
+        - -files~=.*\.py$
+        - -files~=pyproject.toml$
+        - -files~=requirements.*\.txt$
+        - -files~=tox.ini$
+        - -files~=scripts/[^/]+\.sh$
+        - -files~=.github/.*$
+
+    - or:
+      - and:
+        - or:
+          - files~='.*\.md'
+          - files='.markdownlint-cli2.yaml'
+          - files='.github/workflows/docs.yml'
+        - check-success=markdown-lint
+      - and:
+        - -files~='.*\.md'
+        - -files='.markdownlint-cli2.yaml'
+        - -files='.github/workflows/docs.yml'
+
+  actions:
+    merge:
+      method: merge
+    delete_head_branch:
+
 - name: label-cicd
   description: Automatically apply CI/CD label
   conditions:


### PR DESCRIPTION
Add PR merge automation using [Mergify](https://docs.mergify.com).
This configuration is similar to merge automation enabled on the
`instructlab/instructlab` and `instructlab/instructlab-bot` github
repositories.

While it is still possible to merge by hand, the intent of this
automation is merge things automatically once they meet specified
criteria. This should be able to handle merges the vast majority of
the time. Some exceptions include, but aren't limited to:

- Changes to the mergify config (these won't get auto merged)

- Changes to fix something urgently broken

- Dealing with various infrastructure outages

Mergify has a very flexible configuration for defining merge policy.
The configuration proposed here includes:

- Require approvals from 2 maintainers

- There are no outstanding review requests. For example, if someone
  requests review from a specific person, the PR will not get merged
  automatically until that review is given or the review request is
  dismissed.

- There are no "changes requested" reviews still pending. If a past
  review requested changes, the PR will not get automatically merged
  until that person reviews again.

- There are no prohibited labels set on the PR, including `hold`,
  `do-not-merge`, or `needs-rebase`.

- Expected CI jobs are all passing. This is the most verbose part of
  the configuration, because we have to define when we expect the CI
  job and when we don't. This is based on what files changed, and the
  pattern list must stay in sync with the github workflow
  configuration.

On any given PR, you can check on Mergify's analysis of the PR against
the merge criteria by clicking the `Details` link next to Mergify's
line item in the list of checks - the same place where CI results show
up.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
