### PR TITLE
generate_data: Fix check for `output` in results

### DIFF
--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -50,7 +50,7 @@ def _get_question(logger, synth_example):
     if "question" in synth_example:
         return synth_example["question"]
 
-    if "output" not in synth_example:
+    if not synth_example.get("output"):
         raise utils.GenerateException(
             f"Error: output not found in synth_example: {synth_example}"
         )


### PR DESCRIPTION
This code would hit an unepxected traceback if the result had the
`output` column, but its value in a given row was `None`. This check
detects that case and raises the Exception as intended.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
