### PR TITLE
Resolve some trivial TODOs in generate_data()

### DIFF
--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -283,8 +283,6 @@ def generate_data(
         else:
             sdg = sdg_freeform_skill
 
-        # TODO -- there is a parameter for how many samples to generate, but we ignore it so far
-
         logger.debug("Samples: %s" % samples)
         ds = Dataset.from_list(samples)
         logger.debug("Dataset: %s" % ds)

--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -178,19 +178,30 @@ def _sdg_init(pipeline, client, model_family, model_name, num_iters, batched):
 def generate_data(
     logger,
     api_base,
-    tls_insecure,
-    model_family: str,
-    yaml_rules: Optional[str] = None,
-    output_dir: Optional[str] = None,
-    taxonomy: Optional[str] = None,
-    taxonomy_base: Optional[str] = None,
-    # TODO - not used and should be removed from the CLI
-    prompt_file_path: Optional[str] = None,
+    api_key: Optional[str] = None,
+    model_family: Optional[str] = None,
     model_name: Optional[str] = None,
     # TODO - not used -- when batching is enabled, this is relevant.
     # Right now the code hard codes 8 cpus for batching
     num_cpus: Optional[int] = None,
     num_instructions_to_generate: Optional[int] = 30,
+    taxonomy: Optional[str] = None,
+    taxonomy_base: Optional[str] = None,
+    output_dir: Optional[str] = None,
+    # TODO - not used and should be removed from the CLI
+    prompt_file_path: Optional[str] = None,
+    # TODO - probably should be removed
+    rouge_threshold: Optional[float] = None,
+    console_output=True,
+    yaml_rules: Optional[str] = None,
+    chunk_word_count=None,
+    server_ctx_size=None,
+    tls_insecure=False,
+    tls_client_cert: Optional[str] = None,
+    tls_client_key: Optional[str] = None,
+    tls_client_passwd: Optional[str] = None,
+    # TODO need to update the CLI to specify which pipeline to use (simple or full at the moment)
+    pipeline: Optional[str] = "simple",
     # TODO - not used, can probably be removed
     num_prompt_instructions=2,
     # TODO - determine if this is relevant
@@ -199,17 +210,6 @@ def generate_data(
     temperature=1.0,  # temperature per step is provided in the config file
     # TODO - probably should be removed
     top_p=1.0,
-    # TODO - probably should be removed
-    rouge_threshold: Optional[float] = None,
-    console_output=True,
-    api_key: Optional[str] = None,
-    chunk_word_count=None,
-    server_ctx_size=None,
-    tls_client_cert: Optional[str] = None,
-    tls_client_key: Optional[str] = None,
-    tls_client_passwd: Optional[str] = None,
-    # TODO need to update the CLI to specify which pipeline to use (simple or full at the moment)
-    pipeline: Optional[str] = "simple",
 ):
     generate_start = time.time()
 

--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -202,14 +202,6 @@ def generate_data(
     tls_client_passwd: Optional[str] = None,
     # TODO need to update the CLI to specify which pipeline to use (simple or full at the moment)
     pipeline: Optional[str] = "simple",
-    # TODO - not used, can probably be removed
-    num_prompt_instructions=2,
-    # TODO - determine if this is relevant
-    request_batch_size=5,
-    # TODO - probably should be removed
-    temperature=1.0,  # temperature per step is provided in the config file
-    # TODO - probably should be removed
-    top_p=1.0,
 ):
     generate_start = time.time()
 

--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -283,13 +283,6 @@ def generate_data(
         else:
             sdg = sdg_freeform_skill
 
-        if not sdg:
-            # TODO - can be removed once the "full" pipelines are all defined,
-            # as there shouldn't be a code path to get here anymore
-            raise utils.GenerateException(
-                "Error: No SDG pipeline for this leaf node type: %s" % samples[0]
-            )
-
         # TODO -- there is a parameter for how many samples to generate, but we ignore it so far
 
         logger.debug("Samples: %s" % samples)


### PR DESCRIPTION
Some pretty trivial changes to knock out some TODOs in `generate_data()`

commit 51df1954557af91abadd5c4b9f44c7ed1e97a165
```
    Remove unused generate_data() parameters
    
    These parameters aren't being used by the only user of this method,
    and so they can be removed. They also aren't being used within
    generate_data().
```

commit e63bfbe2a7a235302c5d2cc37e13a9ce0ebf7531
```
    Re-order generate_data() params to match CLI
    
    The CLI is the only user of this function, and we have some work
    to do to remove unused or defunct parameters. That's easier if
    they are listed in the same order as they are used!
```

commit 9d7c5211c9c020b106e79547c8abf386b49629b6
```
    Remove TODO about num_instructions_to_generate
    
    We have support for this parameter now.
```

commit 355ff30148a7f3b55073c00003f9080bad9c8ce2
```
    Remove defunct no-pipeline-defined error path
    
    We now have full and simple pipelines defined for knowledge, grounded
    skills, and freeform skills, so this error path can't be hit anymore.
```