### PR TITLE
Fix mismatch in full pipeline outputs

### DIFF
--- a/src/instructlab/sdg/configs/skills/evaluate_freeform_pair.yaml
+++ b/src/instructlab/sdg/configs/skills/evaluate_freeform_pair.yaml
@@ -33,7 +33,7 @@ generation: |
   [End of Question]
 
   [Start of Answer]
-  {answer}
+  {response}
   [End of Answer]
 
   Begin your evaluation by providing a short explanation. Be as objective as possible. After providing your explanation, you must rate the answer on a scale of 1 to 3 as mentioned above. 

--- a/src/instructlab/sdg/configs/skills/evaluate_grounded_pair.yaml
+++ b/src/instructlab/sdg/configs/skills/evaluate_grounded_pair.yaml
@@ -43,7 +43,7 @@ generation: |
   [End of Question]
 
   [Start of Answer]
-  {answer}
+  {response}
   [End of Answer]
 
   * Return the evaluation between [Start of Evaluation] and [End of Evaluation] tags.

--- a/src/instructlab/sdg/default_flows.py
+++ b/src/instructlab/sdg/default_flows.py
@@ -329,7 +329,7 @@ class SynthSkillsFlow(Flow):
                     "client": self.client,
                     "model_id": self.model_id,
                     "model_prompt": _get_model_prompt(self.model_family),
-                    "output_cols": ["answer"],
+                    "output_cols": ["response"],
                     "batch_kwargs": {
                         "num_procs": 8,
                         "batched": self.batched,
@@ -449,7 +449,7 @@ class SynthGroundedSkillsFlow(Flow):
                     "client": self.client,
                     "model_id": self.model_id,
                     "model_prompt": _get_model_prompt(self.model_family),
-                    "output_cols": ["answer"],
+                    "output_cols": ["response"],
                     "batch_kwargs": {
                         "num_procs": 8,
                         "batched": self.batched,


### PR DESCRIPTION

f37ecfc Fix mismatch in full pipeline outputs

commit f37ecfcbfcde5733b58ceea24941c184d1d5e5cf
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jul 3 11:27:38 2024 -0400

    Fix mismatch in full pipeline outputs
    
    The full knowledge pipeline had `question` and `response` as output
    columns, while the skills pipelines used `question` and `answer`.
    
    `generate_data.py` currently expects `response` instead of `answer`.
    Instead of having to deal with both, just standardize on `response`,
    since that seems to be used more frequently. For example, various
    prompt filenames have "response" in their names.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
