### PR TITLE
Handle type conversion errors in FilterByValueBlock

### DIFF
--- a/tests/test_filterblock.py
+++ b/tests/test_filterblock.py
@@ -1,0 +1,31 @@
+# Standard
+from unittest.mock import patch
+import operator
+import unittest
+
+# Third Party
+from datasets import Dataset, Features, Value
+
+# First Party
+from instructlab.sdg.filterblock import FilterByValueBlock
+
+
+class TestFilterByValueBlock(unittest.TestCase):
+    def setUp(self):
+        self.block = FilterByValueBlock(
+            filter_column="age",
+            filter_value=30,
+            operation=operator.eq,
+            convert_dtype=int,
+        )
+        self.dataset = Dataset.from_dict(
+            {"age": ["25", "30", "35", "forty", "45"]},
+            features=Features({"age": Value("string")}),
+        )
+
+    @patch("instructlab.sdg.filterblock.logger")
+    def test_generate_mixed_types(self, mock_logger):
+        filtered_dataset = self.block.generate(self.dataset)
+        self.assertEqual(len(filtered_dataset), 1)
+        self.assertEqual(filtered_dataset["age"], [30])
+        mock_logger.error.assert_called()


### PR DESCRIPTION

97d3fcd filterblock: Don't break when filtering on unexpected data
111711f Add unit tests for sdg.filterblock

commit 97d3fcd6513320edf4195ba62940af3eb79ffd8f
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jul 3 19:53:23 2024 -0400

    filterblock: Don't break when filtering on unexpected data
    
    The previous code in this block did filtering assuming that all
    samples had a value that was correct for the type. For example, when
    filtering on an integer value, it assumed every row had a valid
    integer, where it may instead have garbage.
    
    This change introduces a new helper, _convert_dtype(), which properly
    handles this condition. When the conversion fails on a `ValueError`
    exception, it treats it as `None` instead of allowing the exception to
    be raised up to the caller.
    
    The fix was authored by Shiv in PR #72. I only pulled it out into a
    standalone commit.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
    Co-authored-by: shiv <shivchander.s30@gmail.com>

commit 111711fa419b53e2f31b63bcb91f829eacd55548
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jul 3 19:56:45 2024 -0400

    Add unit tests for sdg.filterblock
    
    This new file introduces some unit tests for the filterblock module.
    A previous commit introduced a bug fix to ensure that unexpected data
    does not cause this block to break. These tests exercise those fixes.
    The tests introduced here will run automatically in CI and help ensure
    that the problem does not reoccur.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
