### PR TITLE
Update generate_data.py to capture context key

### DIFF
--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -272,7 +272,7 @@ def generate_data(
         sdg = None
         if samples[0].get("document"):
             sdg = sdg_knowledge
-        elif samples[0].get("context"):
+        elif samples[0].get("seed_context"):
             sdg = sdg_grounded_skill
         else:
             sdg = sdg_freeform_skill


### PR DESCRIPTION
The key for context is `seed_context` but we were looking for `context`, that was just resulting in all grounded skills to take the freeform workflow instead. With this change, it is getting the seed_context and using the grounded workflow when generating data.


Addresses #97 