### PR TITLE
generate_data: introduce argument `client` to replace 6 others

### DIFF
--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -203,7 +203,7 @@ def _sdg_init(pipeline, client, model_family, model_id, num_instructions_to_gene
 # pylint: disable=unused-argument
 def generate_data(
     logger,
-    api_base,
+    api_base: Optional[str] = None,
     api_key: Optional[str] = None,
     model_family: Optional[str] = None,
     model_name: Optional[str] = None,
@@ -226,6 +226,7 @@ def generate_data(
     tls_client_cert: Optional[str] = None,
     tls_client_key: Optional[str] = None,
     tls_client_passwd: Optional[str] = None,
+    client: Optional[openai.OpenAI] = None,
     pipeline: Optional[str] = "simple",
 ) -> None:
     """Generate data for training and testing a model.
@@ -267,14 +268,15 @@ def generate_data(
 
     logger.debug(f"Generating to: {os.path.join(output_dir, output_file_test)}")
 
-    orig_cert = (tls_client_cert, tls_client_key, tls_client_passwd)
-    cert = tuple(item for item in orig_cert if item)
-    verify = not tls_insecure
-    client = openai.OpenAI(
-        base_url=api_base,
-        api_key=api_key,
-        http_client=httpx.Client(cert=cert, verify=verify),
-    )
+    if not client:
+        orig_cert = (tls_client_cert, tls_client_key, tls_client_passwd)
+        cert = tuple(item for item in orig_cert if item)
+        http_client = httpx.Client(cert=cert, verify=not tls_insecure)
+        client = openai.OpenAI(
+            base_url=api_base,
+            api_key=api_key,
+            http_client=http_client,
+        )
 
     if models.get_model_family(model_family, model_name) == "mixtral":
         model_family = MODEL_FAMILY_MIXTRAL


### PR DESCRIPTION
The `generate_data` argument list has become quite large (21).
It's necessary to refactor the code to maintain cleanliness and readability.

This PR prepares for complete replacement of six arguments
api_base, api_key, tls_insecure, tls_client_cert, tls_client_key, tls_client_passwd
with single `client` argument.

Make local variable `client` also argument to allow
creation the client object with api and tsl parameters in calling
CLI function and provide it to `generate_data`.

After updating CLI and replacing six arguments
api_base, api_key, tls_insecure, tls_client_cert, tls_client_key, tls_client_passwd
with single `client` argument remove that six arguments and
local client creation from generate_data().