### PR TITLE
Remove batch_kwargs

### DIFF
--- a/scripts/test_freeform_skills.py
+++ b/scripts/test_freeform_skills.py
@@ -5,7 +5,7 @@ from openai import OpenAI
 # First Party
 from src.instructlab.sdg import SDG
 from src.instructlab.sdg.default_flows import SynthSkillsFlow
-from src.instructlab.sdg.pipeline import Pipeline
+from src.instructlab.sdg.pipeline import Pipeline, PipelineContext
 
 # for vLLM endpoints, the api_key remains "EMPTY"
 openai_api_key = "EMPTY"
@@ -49,7 +49,9 @@ Sincerely,
 
 ds = Dataset.from_list(samples)
 
-skills_flow = SynthSkillsFlow(client, "mixtral", teacher_model, 1).get_flow()
+ctx = PipelineContext(client, "mixtral", teacher_model, 1)
+
+skills_flow = SynthSkillsFlow(ctx).get_flow()
 skills_pipe = Pipeline(skills_flow)
 
 sdg = SDG([skills_pipe])

--- a/scripts/test_grounded_skills.py
+++ b/scripts/test_grounded_skills.py
@@ -5,7 +5,7 @@ from openai import OpenAI
 # First Party
 from src.instructlab.sdg import SDG
 from src.instructlab.sdg.default_flows import SynthGroundedSkillsFlow
-from src.instructlab.sdg.pipeline import Pipeline
+from src.instructlab.sdg.pipeline import Pipeline, PipelineContext
 
 # for vLLM endpoints, the api_key remains "EMPTY"
 openai_api_key = "EMPTY"
@@ -97,7 +97,9 @@ samples = [
 
 ds = Dataset.from_list(samples)
 
-skills_flow = SynthGroundedSkillsFlow(client, "mixtral", teacher_model, 10).get_flow()
+ctx = PipelineContext(client, "mixtral", teacher_model, 10)
+
+skills_flow = SynthGroundedSkillsFlow(ctx).get_flow()
 skills_pipe = Pipeline(skills_flow)
 
 sdg = SDG([skills_pipe])

--- a/scripts/test_knowledge.py
+++ b/scripts/test_knowledge.py
@@ -8,7 +8,7 @@ from openai import OpenAI
 # First Party
 from src.instructlab.sdg import SDG
 from src.instructlab.sdg.default_flows import MMLUBenchFlow, SynthKnowledgeFlow
-from src.instructlab.sdg.pipeline import Pipeline
+from src.instructlab.sdg.pipeline import Pipeline, PipelineContext
 
 # Please don't add you vLLM endpoint key here
 openai_api_key = "EMPTY"
@@ -38,12 +38,13 @@ samples = [
 
 ds = Dataset.from_list(samples)
 
-mmlu_flow = MMLUBenchFlow(client, "mixtral", teacher_model, 1).get_flow()
-knowledge_flow = SynthKnowledgeFlow(client, "mixtral", teacher_model, 1).get_flow()
-knowledge_pipe = Pipeline(knowledge_flow)
-mmlu_pipe = Pipeline(mmlu_flow)
+ctx = PipelineContext(client, "mixtral", teacher_model, 1)
 
-sdg = SDG([mmlu_pipe, knowledge_pipe])
+mmlu_flow = MMLUBenchFlow(ctx).get_flow()
+knowledge_flow = SynthKnowledgeFlow(ctx).get_flow()
+knowledge_pipe = Pipeline(mmlu_flow + knowledge_flow)
+
+sdg = SDG([knowledge_pipe])
 mmlubench_data = sdg.generate(ds)
 
 print(mmlubench_data)

--- a/src/instructlab/sdg/block.py
+++ b/src/instructlab/sdg/block.py
@@ -14,7 +14,8 @@ logger = setup_logger(__name__)
 
 
 class Block(ABC):
-    def __init__(self, block_name: str) -> None:
+    def __init__(self, ctx, block_name: str) -> None:
+        self.ctx = ctx
         self.block_name = block_name
 
     @staticmethod

--- a/src/instructlab/sdg/block.py
+++ b/src/instructlab/sdg/block.py
@@ -3,6 +3,7 @@
 from abc import ABC
 from collections import ChainMap
 from typing import Any, Dict, Union
+import os.path
 
 # Third Party
 import yaml
@@ -42,8 +43,13 @@ class Block(ABC):
         """
         Load the configuration file for this block.
 
+        If the supplied configuration file is a relative path, it is assumed
+        to be part of this Python package.
+
         :param config_path: The path to the configuration file.
         :return: The loaded configuration.
         """
+        if not os.path.isabs(config_path):
+            config_path = os.path.join(self.ctx.sdg_base, config_path)
         with open(config_path, "r", encoding="utf-8") as config_file:
             return yaml.safe_load(config_file)

--- a/src/instructlab/sdg/default_flows.py
+++ b/src/instructlab/sdg/default_flows.py
@@ -2,7 +2,6 @@
 # Standard
 from abc import ABC, abstractmethod
 import operator
-import os
 
 # Local
 from .filterblock import FilterByValueBlock
@@ -42,8 +41,8 @@ class _SimpleFlow(Flow):
 class SimpleKnowledgeFlow(_SimpleFlow):
     def get_flow(self) -> list:
         flow = super().get_flow()
-        flow[0]["block_config"]["config_path"] = os.path.join(
-            self.ctx.sdg_base, "configs/knowledge/simple_generate_qa.yaml"
+        flow[0]["block_config"]["config_path"] = (
+            "configs/knowledge/simple_generate_qa.yaml"
         )
         flow[0]["block_config"]["block_name"] = "gen_knowledge"
         return flow
@@ -52,8 +51,8 @@ class SimpleKnowledgeFlow(_SimpleFlow):
 class SimpleFreeformSkillFlow(_SimpleFlow):
     def get_flow(self) -> list:
         flow = super().get_flow()
-        flow[0]["block_config"]["config_path"] = os.path.join(
-            self.ctx.sdg_base, "configs/skills/simple_generate_qa_freeform.yaml"
+        flow[0]["block_config"]["config_path"] = (
+            "configs/skills/simple_generate_qa_freeform.yaml"
         )
         flow[0]["block_config"]["block_name"] = "gen_skill_freeform"
         return flow
@@ -62,8 +61,8 @@ class SimpleFreeformSkillFlow(_SimpleFlow):
 class SimpleGroundedSkillFlow(_SimpleFlow):
     def get_flow(self) -> list:
         flow = super().get_flow()
-        flow[0]["block_config"]["config_path"] = os.path.join(
-            self.ctx.sdg_base, "configs/skills/simple_generate_qa_grounded.yaml"
+        flow[0]["block_config"]["config_path"] = (
+            "configs/skills/simple_generate_qa_grounded.yaml"
         )
         flow[0]["block_config"]["block_name"] = "gen_skill_grounded"
         return flow
@@ -76,9 +75,7 @@ class MMLUBenchFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "gen_mmlu_knowledge",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base, "configs/knowledge/mcq_generation.yaml"
-                    ),
+                    "config_path": "configs/knowledge/mcq_generation.yaml",
                     "output_cols": ["mmlubench_question", "mmlubench_answer"],
                 },
                 "gen_kwargs": {
@@ -97,10 +94,7 @@ class SynthKnowledgeFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "gen_knowledge",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base,
-                        "configs/knowledge/generate_questions_responses.yaml",
-                    ),
+                    "config_path": "configs/knowledge/generate_questions_responses.yaml",
                     "output_cols": ["question", "response"],
                     "parser_kwargs": {
                         "parser_name": "custom",
@@ -117,10 +111,7 @@ class SynthKnowledgeFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "eval_faithfulness_qa_pair",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base,
-                        "configs/knowledge/evaluate_faithfulness.yaml",
-                    ),
+                    "config_path": "configs/knowledge/evaluate_faithfulness.yaml",
                     "output_cols": ["explanation", "judgment"],
                 },
                 "gen_kwargs": {
@@ -144,10 +135,7 @@ class SynthKnowledgeFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "eval_relevancy_qa_pair",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base,
-                        "configs/knowledge/evaluate_relevancy.yaml",
-                    ),
+                    "config_path": "configs/knowledge/evaluate_relevancy.yaml",
                     "output_cols": ["feedback", "score"],
                 },
                 "gen_kwargs": {
@@ -172,9 +160,7 @@ class SynthKnowledgeFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "eval_verify_question",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base, "configs/knowledge/evaluate_question.yaml"
-                    ),
+                    "config_path": "configs/knowledge/evaluate_question.yaml",
                     "output_cols": ["explanation", "rating"],
                 },
                 "gen_kwargs": {
@@ -205,10 +191,7 @@ class SynthSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "gen_questions",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base,
-                        "configs/skills/freeform_questions.yaml",
-                    ),
+                    "config_path": "configs/skills/freeform_questions.yaml",
                     "output_cols": ["question"],
                     "batch_kwargs": {
                         "num_samples": self.ctx.num_instructions_to_generate,
@@ -220,10 +203,7 @@ class SynthSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "eval_questions",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base,
-                        "configs/skills/evaluate_freeform_questions.yaml",
-                    ),
+                    "config_path": "configs/skills/evaluate_freeform_questions.yaml",
                     "output_cols": ["evaluation", "score"],
                 },
             },
@@ -245,10 +225,7 @@ class SynthSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "gen_responses",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base,
-                        "configs/skills/freeform_responses.yaml",
-                    ),
+                    "config_path": "configs/skills/freeform_responses.yaml",
                     "output_cols": ["response"],
                 },
             },
@@ -256,10 +233,7 @@ class SynthSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "evaluate_qa_pair",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base,
-                        "configs/skills/evaluate_freeform_pair.yaml",
-                    ),
+                    "config_path": "configs/skills/evaluate_freeform_pair.yaml",
                     "output_cols": ["evaluation", "score"],
                 },
             },
@@ -287,10 +261,7 @@ class SynthGroundedSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "gen_contexts",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base,
-                        "configs/skills/contexts.yaml",
-                    ),
+                    "config_path": "configs/skills/contexts.yaml",
                     "output_cols": ["context"],
                 },
                 "gen_kwargs": {
@@ -304,10 +275,7 @@ class SynthGroundedSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "gen_grounded_questions",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base,
-                        "configs/skills/grounded_questions.yaml",
-                    ),
+                    "config_path": "configs/skills/grounded_questions.yaml",
                     "output_cols": ["question"],
                     "batch_kwargs": {
                         "num_samples": 3,
@@ -319,10 +287,7 @@ class SynthGroundedSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "eval_grounded_questions",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base,
-                        "configs/skills/evaluate_grounded_questions.yaml",
-                    ),
+                    "config_path": "configs/skills/evaluate_grounded_questions.yaml",
                     "output_cols": ["evaluation", "score"],
                 },
             },
@@ -344,10 +309,7 @@ class SynthGroundedSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "gen_grounded_responses",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base,
-                        "configs/skills/grounded_responses.yaml",
-                    ),
+                    "config_path": "configs/skills/grounded_responses.yaml",
                     "output_cols": ["response"],
                 },
             },
@@ -355,10 +317,7 @@ class SynthGroundedSkillsFlow(Flow):
                 "block_type": LLMBlock,
                 "block_config": {
                     "block_name": "evaluate_grounded_qa_pair",
-                    "config_path": os.path.join(
-                        self.ctx.sdg_base,
-                        "configs/skills/evaluate_grounded_pair.yaml",
-                    ),
+                    "config_path": "configs/skills/evaluate_grounded_pair.yaml",
                     "output_cols": ["evaluation", "score"],
                 },
             },

--- a/src/instructlab/sdg/default_flows.py
+++ b/src/instructlab/sdg/default_flows.py
@@ -125,9 +125,6 @@ class SynthKnowledgeFlow(Flow):
                     "filter_column": "judgment",
                     "filter_value": "YES",
                     "operation": operator.eq,
-                    "batch_kwargs": {
-                        "num_procs": 8,
-                    },
                 },
                 "drop_columns": ["judgment", "explanation"],
             },
@@ -150,9 +147,6 @@ class SynthKnowledgeFlow(Flow):
                     "filter_value": 2.0,
                     "operation": operator.eq,
                     "convert_dtype": float,
-                    "batch_kwargs": {
-                        "num_procs": 8,
-                    },
                 },
                 "drop_columns": ["feedback", "score"],
             },
@@ -175,9 +169,6 @@ class SynthKnowledgeFlow(Flow):
                     "filter_value": 1.0,
                     "operation": operator.eq,
                     "convert_dtype": float,
-                    "batch_kwargs": {
-                        "num_procs": 8,
-                    },
                 },
                 "drop_columns": ["explanation", "rating", "__index_level_0__"],
             },
@@ -215,9 +206,6 @@ class SynthSkillsFlow(Flow):
                     "filter_value": 1.0,
                     "operation": operator.eq,
                     "convert_dtype": float,
-                    "batch_kwargs": {
-                        "num_procs": 8,
-                    },
                 },
                 "drop_columns": ["evaluation", "score", "num_samples"],
             },
@@ -245,9 +233,6 @@ class SynthSkillsFlow(Flow):
                     "filter_value": 2.0,
                     "operation": operator.ge,
                     "convert_dtype": float,
-                    "batch_kwargs": {
-                        "num_procs": 8,
-                    },
                 },
                 "drop_columns": ["evaluation", "score"],
             },
@@ -299,9 +284,6 @@ class SynthGroundedSkillsFlow(Flow):
                     "filter_value": 1.0,
                     "operation": operator.eq,
                     "convert_dtype": float,
-                    "batch_kwargs": {
-                        "num_procs": 8,
-                    },
                 },
                 "drop_columns": ["evaluation", "score", "num_samples"],
             },
@@ -329,9 +311,6 @@ class SynthGroundedSkillsFlow(Flow):
                     "filter_value": 2.0,
                     "operation": operator.ge,
                     "convert_dtype": float,
-                    "batch_kwargs": {
-                        "num_procs": 8,
-                    },
                 },
             },
             {
@@ -340,10 +319,6 @@ class SynthGroundedSkillsFlow(Flow):
                     "block_name": "combine_question_and_context",
                     "columns": ["context", "question"],
                     "output_col": "question",
-                    "batch_kwargs": {
-                        "num_procs": 8,
-                        "batched": True,
-                    },
                 },
             },
         ]

--- a/src/instructlab/sdg/default_flows.py
+++ b/src/instructlab/sdg/default_flows.py
@@ -10,23 +10,6 @@ from .filterblock import FilterByValueBlock
 from .llmblock import LLMBlock
 from .utilblocks import CombineColumnsBlock
 
-MODEL_FAMILY_MIXTRAL = "mixtral"
-MODEL_FAMILY_MERLINITE = "merlinite"
-
-_MODEL_PROMPT_MIXTRAL = "<s> [INST] {prompt} [/INST]"
-_MODEL_PROMPT_MERLINITE = "'<|system|>\nYou are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior.\n<|user|>\n{prompt}\n<|assistant|>\n'"
-
-_MODEL_PROMPTS = {
-    MODEL_FAMILY_MIXTRAL: _MODEL_PROMPT_MIXTRAL,
-    MODEL_FAMILY_MERLINITE: _MODEL_PROMPT_MERLINITE,
-}
-
-
-def _get_model_prompt(model_family):
-    if model_family not in _MODEL_PROMPTS:
-        raise ValueError(f"Unknown model family: {model_family}")
-    return _MODEL_PROMPTS[model_family]
-
 
 class Flow(ABC):
     def __init__(
@@ -53,7 +36,7 @@ class _SimpleFlow(Flow):
                     "config_path": "",  # must be set by subclass
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["output"],
                 },
                 "gen_kwargs": {
@@ -110,7 +93,7 @@ class MMLUBenchFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["mmlubench_question", "mmlubench_answer"],
                 },
                 "gen_kwargs": {
@@ -135,7 +118,7 @@ class SynthKnowledgeFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["question", "response"],
                     "parser_kwargs": {
                         "parser_name": "custom",
@@ -157,7 +140,7 @@ class SynthKnowledgeFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["explanation", "judgment"],
                 },
                 "gen_kwargs": {
@@ -186,7 +169,7 @@ class SynthKnowledgeFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["feedback", "score"],
                 },
                 "gen_kwargs": {
@@ -216,7 +199,7 @@ class SynthKnowledgeFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["explanation", "rating"],
                 },
                 "gen_kwargs": {
@@ -253,7 +236,7 @@ class SynthSkillsFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["question"],
                     "batch_kwargs": {
                         "num_samples": self.num_instructions_to_generate,
@@ -271,7 +254,7 @@ class SynthSkillsFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["evaluation", "score"],
                 },
             },
@@ -299,7 +282,7 @@ class SynthSkillsFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["response"],
                 },
             },
@@ -313,7 +296,7 @@ class SynthSkillsFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["evaluation", "score"],
                 },
             },
@@ -347,7 +330,7 @@ class SynthGroundedSkillsFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["context"],
                 },
                 "gen_kwargs": {
@@ -367,7 +350,7 @@ class SynthGroundedSkillsFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["question"],
                     "batch_kwargs": {
                         "num_samples": 3,
@@ -385,7 +368,7 @@ class SynthGroundedSkillsFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["evaluation", "score"],
                 },
             },
@@ -413,7 +396,7 @@ class SynthGroundedSkillsFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["response"],
                 },
             },
@@ -427,7 +410,7 @@ class SynthGroundedSkillsFlow(Flow):
                     ),
                     "client": self.client,
                     "model_id": self.model_id,
-                    "model_prompt": _get_model_prompt(self.model_family),
+                    "model_family": self.model_family,
                     "output_cols": ["evaluation", "score"],
                 },
             },

--- a/src/instructlab/sdg/default_flows.py
+++ b/src/instructlab/sdg/default_flows.py
@@ -184,9 +184,7 @@ class SynthSkillsFlow(Flow):
                     "block_name": "gen_questions",
                     "config_path": "configs/skills/freeform_questions.yaml",
                     "output_cols": ["question"],
-                    "batch_kwargs": {
-                        "num_samples": self.ctx.num_instructions_to_generate,
-                    },
+                    "add_num_samples": True,
                 },
                 "drop_duplicates": ["question"],
             },
@@ -262,9 +260,7 @@ class SynthGroundedSkillsFlow(Flow):
                     "block_name": "gen_grounded_questions",
                     "config_path": "configs/skills/grounded_questions.yaml",
                     "output_cols": ["question"],
-                    "batch_kwargs": {
-                        "num_samples": 3,
-                    },
+                    "add_num_samples": True,
                 },
                 "drop_duplicates": ["question"],
             },

--- a/src/instructlab/sdg/filterblock.py
+++ b/src/instructlab/sdg/filterblock.py
@@ -46,6 +46,7 @@ class FilterByValueBlock(Block):
     def __init__(
         self,
         ctx,
+        block_name,
         filter_column,
         filter_value,
         operation,
@@ -57,6 +58,7 @@ class FilterByValueBlock(Block):
 
         Parameters:
         - ctx (PipelineContext): A PipelineContext object containing runtime parameters.
+        - block_name (str): An identifier for this block.
         - filter_column (str): The name of the column in the dataset to apply the filter on.
         - filter_value (any or list of any): The value(s) to filter by.
         - operation (callable): A function that takes two arguments (column value and filter value) and returns a boolean indicating whether the row should be included in the filtered dataset.
@@ -66,7 +68,7 @@ class FilterByValueBlock(Block):
         Returns:
         None
         """
-        super().__init__(ctx, block_name=self.__class__.__name__)
+        super().__init__(ctx, block_name)
         self.value = filter_value if isinstance(filter_value, list) else [filter_value]
         self.column_name = filter_column
         self.operation = operation

--- a/src/instructlab/sdg/filterblock.py
+++ b/src/instructlab/sdg/filterblock.py
@@ -11,12 +11,19 @@ logger = setup_logger(__name__)
 
 class FilterByValueBlock(Block):
     def __init__(
-        self, filter_column, filter_value, operation, convert_dtype=None, **batch_kwargs
+        self,
+        ctx,
+        filter_column,
+        filter_value,
+        operation,
+        convert_dtype=None,
+        **batch_kwargs,
     ) -> None:
         """
         Initializes a new instance of the FilterByValueBlock class.
 
         Parameters:
+        - ctx (PipelineContext): A PipelineContext object containing runtime parameters.
         - filter_column (str): The name of the column in the dataset to apply the filter on.
         - filter_value (any or list of any): The value(s) to filter by.
         - operation (callable): A function that takes two arguments (column value and filter value) and returns a boolean indicating whether the row should be included in the filtered dataset.
@@ -26,7 +33,7 @@ class FilterByValueBlock(Block):
         Returns:
         None
         """
-        super().__init__(block_name=self.__class__.__name__)
+        super().__init__(ctx, block_name=self.__class__.__name__)
         self.value = filter_value if isinstance(filter_value, list) else [filter_value]
         self.column_name = filter_column
         self.operation = operation

--- a/src/instructlab/sdg/filterblock.py
+++ b/src/instructlab/sdg/filterblock.py
@@ -51,7 +51,6 @@ class FilterByValueBlock(Block):
         filter_value,
         operation,
         convert_dtype=None,
-        **batch_kwargs,
     ) -> None:
         """
         Initializes a new instance of the FilterByValueBlock class.
@@ -63,7 +62,6 @@ class FilterByValueBlock(Block):
         - filter_value (any or list of any): The value(s) to filter by.
         - operation (callable): A function that takes two arguments (column value and filter value) and returns a boolean indicating whether the row should be included in the filtered dataset.
         - convert_dtype (callable, optional): A function to convert the data type of the filter column before applying the filter. Defaults to None.
-        - **batch_kwargs: Additional kwargs for batch processing.
 
         Returns:
         None
@@ -73,14 +71,13 @@ class FilterByValueBlock(Block):
         self.column_name = filter_column
         self.operation = operation
         self.convert_dtype = convert_dtype
-        self.num_procs = batch_kwargs.get("num_procs", 1)
 
     def generate(self, samples) -> Dataset:
         if self.convert_dtype:
             samples = _map_dtype(
-                samples, self.column_name, self.convert_dtype, self.num_procs
+                samples, self.column_name, self.convert_dtype, self.ctx.num_procs
             )
 
         return _filter_by_values(
-            samples, self.column_name, self.operation, self.value, self.num_procs
+            samples, self.column_name, self.operation, self.value, self.ctx.num_procs
         )

--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -18,8 +18,6 @@ import openai
 # pylint: disable=ungrouped-imports
 from instructlab.sdg import SDG, utils
 from instructlab.sdg.default_flows import (
-    MODEL_FAMILY_MERLINITE,
-    MODEL_FAMILY_MIXTRAL,
     MMLUBenchFlow,
     SimpleFreeformSkillFlow,
     SimpleGroundedSkillFlow,
@@ -28,6 +26,7 @@ from instructlab.sdg.default_flows import (
     SynthKnowledgeFlow,
     SynthSkillsFlow,
 )
+from instructlab.sdg.llmblock import MODEL_FAMILY_MERLINITE, MODEL_FAMILY_MIXTRAL
 from instructlab.sdg.pipeline import Pipeline
 from instructlab.sdg.utils import models
 from instructlab.sdg.utils.taxonomy import (

--- a/src/instructlab/sdg/llmblock.py
+++ b/src/instructlab/sdg/llmblock.py
@@ -61,7 +61,7 @@ class LLMBlock(Block):
         output_cols,
         add_num_samples=False,
         parser_kwargs={},
-        **batch_kwargs,
+        batch_kwargs={},
     ) -> None:
         super().__init__(ctx, block_name)
         self.block_config = self._load_config(config_path)
@@ -72,7 +72,7 @@ class LLMBlock(Block):
         self.model_prompt = _get_model_prompt(self.ctx.model_family)
         self.add_num_samples = add_num_samples
         self.output_cols = output_cols
-        self.batch_params = batch_kwargs.get("batch_kwargs", {})
+        self.batch_params = batch_kwargs
         self.parser_name = parser_kwargs.get("parser_name", None)
         self.parsing_pattern = parser_kwargs.get("parsing_pattern", None)
         self.parser_cleanup_tags = parser_kwargs.get("parser_cleanup_tags", None)
@@ -216,7 +216,7 @@ class ConditionalLLMBlock(LLMBlock):
         selector_column_name,
         add_num_samples=False,
         parser_kwargs={},
-        **batch_kwargs,
+        batch_kwargs={},
     ) -> None:
         super().__init__(
             ctx,
@@ -225,7 +225,7 @@ class ConditionalLLMBlock(LLMBlock):
             output_cols,
             add_num_samples=add_num_samples,
             parser_kwargs=parser_kwargs,
-            **batch_kwargs,
+            batch_kwargs=batch_kwargs,
         )
         self.selector_column_name = selector_column_name
         self.prompt_template = {}

--- a/src/instructlab/sdg/llmblock.py
+++ b/src/instructlab/sdg/llmblock.py
@@ -61,7 +61,6 @@ class LLMBlock(Block):
         output_cols,
         add_num_samples=False,
         parser_kwargs={},
-        batch_kwargs={},
     ) -> None:
         super().__init__(ctx, block_name)
         self.block_config = self._load_config(config_path)
@@ -72,7 +71,6 @@ class LLMBlock(Block):
         self.model_prompt = _get_model_prompt(self.ctx.model_family)
         self.add_num_samples = add_num_samples
         self.output_cols = output_cols
-        self.batch_params = batch_kwargs
         self.parser_name = parser_kwargs.get("parser_name", None)
         self.parsing_pattern = parser_kwargs.get("parsing_pattern", None)
         self.parser_cleanup_tags = parser_kwargs.get("parser_cleanup_tags", None)
@@ -216,7 +214,6 @@ class ConditionalLLMBlock(LLMBlock):
         selector_column_name,
         add_num_samples=False,
         parser_kwargs={},
-        batch_kwargs={},
     ) -> None:
         super().__init__(
             ctx,
@@ -225,7 +222,6 @@ class ConditionalLLMBlock(LLMBlock):
             output_cols,
             add_num_samples=add_num_samples,
             parser_kwargs=parser_kwargs,
-            batch_kwargs=batch_kwargs,
         )
         self.selector_column_name = selector_column_name
         self.prompt_template = {}

--- a/src/instructlab/sdg/llmblock.py
+++ b/src/instructlab/sdg/llmblock.py
@@ -59,6 +59,7 @@ class LLMBlock(Block):
         block_name,
         config_path,
         output_cols,
+        add_num_samples=False,
         parser_kwargs={},
         **batch_kwargs,
     ) -> None:
@@ -69,6 +70,7 @@ class LLMBlock(Block):
         )
         self.prompt_template = self.prompt_struct.format(**self.block_config)
         self.model_prompt = _get_model_prompt(self.ctx.model_family)
+        self.add_num_samples = add_num_samples
         self.output_cols = output_cols
         self.batch_params = batch_kwargs.get("batch_kwargs", {})
         self.parser_name = parser_kwargs.get("parser_name", None)
@@ -156,11 +158,12 @@ class LLMBlock(Block):
 
         :return: The parsed output after generation.
         """
-        num_samples = self.batch_params.get("num_samples", None)
         logger.debug("Generating outputs for {} samples".format(len(samples)))
 
-        if (num_samples is not None) and ("num_samples" not in samples.column_names):
-            samples = samples.add_column("num_samples", [num_samples] * len(samples))
+        if self.add_num_samples and ("num_samples" not in samples.column_names):
+            samples = samples.add_column(
+                "num_samples", [self.ctx.num_instructions_to_generate] * len(samples)
+            )
 
         # validate each sample
         # Log errors and remove invalid samples
@@ -211,6 +214,7 @@ class ConditionalLLMBlock(LLMBlock):
         config_paths,
         output_cols,
         selector_column_name,
+        add_num_samples=False,
         parser_kwargs={},
         **batch_kwargs,
     ) -> None:
@@ -219,6 +223,7 @@ class ConditionalLLMBlock(LLMBlock):
             block_name,
             config_paths[0][0],
             output_cols,
+            add_num_samples=add_num_samples,
             parser_kwargs=parser_kwargs,
             **batch_kwargs,
         )

--- a/src/instructlab/sdg/pipeline.py
+++ b/src/instructlab/sdg/pipeline.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+# Standard
+from importlib import resources
+
 # Third Party
 from datasets import Dataset
 
@@ -8,12 +11,25 @@ from .logger_config import setup_logger
 logger = setup_logger(__name__)
 
 
+class PipelineContext:
+    def __init__(
+        self, client, model_family, model_id, num_instructions_to_generate
+    ) -> None:
+        self.client = client
+        self.model_family = model_family
+        self.model_id = model_id
+        self.num_instructions_to_generate = num_instructions_to_generate
+        self.sdg_base = resources.files(__package__)
+
+
 class Pipeline:
-    def __init__(self, chained_blocks: list) -> None:
+    def __init__(self, ctx, chained_blocks: list) -> None:
         """
         Initialize the Pipeline class with a configuration dictionary.
         config_dict: the run config py or yaml loaded into a dictionary
         """
+        # ctx is a PipelineContext object that supplies context configuration to every block
+        self.ctx = ctx
         # pipeline config is the run configuration that consists of the pipeline steps
         self.chained_blocks = chained_blocks
 
@@ -36,7 +52,7 @@ class Pipeline:
             drop_columns = block_prop.get("drop_columns", [])
             gen_kwargs = block_prop.get("gen_kwargs", {})
             drop_duplicates_cols = block_prop.get("drop_duplicates", False)
-            block = block_type(**block_config)
+            block = block_type(self.ctx, **block_config)
 
             logger.info("Running block: %s", block_config["block_name"])
             logger.info(dataset)

--- a/src/instructlab/sdg/pipeline.py
+++ b/src/instructlab/sdg/pipeline.py
@@ -20,6 +20,8 @@ class PipelineContext:
         self.model_id = model_id
         self.num_instructions_to_generate = num_instructions_to_generate
         self.sdg_base = resources.files(__package__)
+        # FIXME: base this on the available number of CPUs
+        self.num_procs = 8
 
 
 class Pipeline:

--- a/src/instructlab/sdg/utilblocks.py
+++ b/src/instructlab/sdg/utilblocks.py
@@ -10,9 +10,11 @@ logger = setup_logger(__name__)
 
 
 class SamplePopulatorBlock(Block):
-    def __init__(self, config_paths, column_name, post_fix="", **batch_kwargs) -> None:
+    def __init__(
+        self, ctx, config_paths, column_name, post_fix="", **batch_kwargs
+    ) -> None:
         super().__init__(
-            block_name=self.__class__.__name__
+            ctx, block_name=self.__class__.__name__
         )  # Call the base class's __init__
         self.configs = {}
         for config in config_paths:
@@ -35,8 +37,8 @@ class SamplePopulatorBlock(Block):
 
 
 class SelectorBlock(Block):
-    def __init__(self, choice_map, choice_col, output_col, **batch_kwargs) -> None:
-        super().__init__(block_name=self.__class__.__name__)
+    def __init__(self, ctx, choice_map, choice_col, output_col, **batch_kwargs) -> None:
+        super().__init__(ctx, block_name=self.__class__.__name__)
         self.choice_map = choice_map
         self.choice_col = choice_col
         self.output_col = output_col
@@ -52,8 +54,10 @@ class SelectorBlock(Block):
 
 
 class CombineColumnsBlock(Block):
-    def __init__(self, columns, output_col, separator="\n\n", **batch_kwargs) -> None:
-        super().__init__(block_name=self.__class__.__name__)
+    def __init__(
+        self, ctx, columns, output_col, separator="\n\n", **batch_kwargs
+    ) -> None:
+        super().__init__(ctx, block_name=self.__class__.__name__)
         self.columns = columns
         self.output_col = output_col
         self.separator = separator

--- a/src/instructlab/sdg/utilblocks.py
+++ b/src/instructlab/sdg/utilblocks.py
@@ -10,9 +10,7 @@ logger = setup_logger(__name__)
 
 
 class SamplePopulatorBlock(Block):
-    def __init__(
-        self, ctx, block_name, config_paths, column_name, post_fix="", **batch_kwargs
-    ) -> None:
+    def __init__(self, ctx, block_name, config_paths, column_name, post_fix="") -> None:
         super().__init__(ctx, block_name)
         self.configs = {}
         for config in config_paths:
@@ -23,7 +21,6 @@ class SamplePopulatorBlock(Block):
             config_key = config.split("/")[-1].split(".")[0]
             self.configs[config_key] = self._load_config(config_name)
         self.column_name = column_name
-        self.num_procs = batch_kwargs.get("num_procs", 8)
 
     # Using a static method to avoid serializing self when using multiprocessing
     @staticmethod
@@ -35,19 +32,16 @@ class SamplePopulatorBlock(Block):
 
     def generate(self, samples) -> Dataset:
         return self._map_populate_samples(
-            samples, self.configs, self.column_name, self.num_procs
+            samples, self.configs, self.column_name, self.ctx.num_procs
         )
 
 
 class SelectorBlock(Block):
-    def __init__(
-        self, ctx, block_name, choice_map, choice_col, output_col, **batch_kwargs
-    ) -> None:
+    def __init__(self, ctx, block_name, choice_map, choice_col, output_col) -> None:
         super().__init__(ctx, block_name)
         self.choice_map = choice_map
         self.choice_col = choice_col
         self.output_col = output_col
-        self.num_procs = batch_kwargs.get("num_procs", 8)
 
     # Using a static method to avoid serializing self when using multiprocessing
     @staticmethod
@@ -64,19 +58,16 @@ class SelectorBlock(Block):
             self.choice_map,
             self.choice_col,
             self.output_col,
-            self.num_procs,
+            self.ctx.num_procs,
         )
 
 
 class CombineColumnsBlock(Block):
-    def __init__(
-        self, ctx, block_name, columns, output_col, separator="\n\n", **batch_kwargs
-    ) -> None:
+    def __init__(self, ctx, block_name, columns, output_col, separator="\n\n") -> None:
         super().__init__(ctx, block_name)
         self.columns = columns
         self.output_col = output_col
         self.separator = separator
-        self.num_procs = batch_kwargs.get("num_procs", 8)
 
     # Using a static method to avoid serializing self when using multiprocessing
     @staticmethod
@@ -89,5 +80,5 @@ class CombineColumnsBlock(Block):
 
     def generate(self, samples: Dataset) -> Dataset:
         return self._map_combine(
-            samples, self.columns, self.output_col, self.separator, self.num_procs
+            samples, self.columns, self.output_col, self.separator, self.ctx.num_procs
         )

--- a/src/instructlab/sdg/utilblocks.py
+++ b/src/instructlab/sdg/utilblocks.py
@@ -11,11 +11,9 @@ logger = setup_logger(__name__)
 
 class SamplePopulatorBlock(Block):
     def __init__(
-        self, ctx, config_paths, column_name, post_fix="", **batch_kwargs
+        self, ctx, block_name, config_paths, column_name, post_fix="", **batch_kwargs
     ) -> None:
-        super().__init__(
-            ctx, block_name=self.__class__.__name__
-        )  # Call the base class's __init__
+        super().__init__(ctx, block_name)
         self.configs = {}
         for config in config_paths:
             if post_fix:
@@ -42,8 +40,10 @@ class SamplePopulatorBlock(Block):
 
 
 class SelectorBlock(Block):
-    def __init__(self, ctx, choice_map, choice_col, output_col, **batch_kwargs) -> None:
-        super().__init__(ctx, block_name=self.__class__.__name__)
+    def __init__(
+        self, ctx, block_name, choice_map, choice_col, output_col, **batch_kwargs
+    ) -> None:
+        super().__init__(ctx, block_name)
         self.choice_map = choice_map
         self.choice_col = choice_col
         self.output_col = output_col
@@ -70,9 +70,9 @@ class SelectorBlock(Block):
 
 class CombineColumnsBlock(Block):
     def __init__(
-        self, ctx, columns, output_col, separator="\n\n", **batch_kwargs
+        self, ctx, block_name, columns, output_col, separator="\n\n", **batch_kwargs
     ) -> None:
-        super().__init__(ctx, block_name=self.__class__.__name__)
+        super().__init__(ctx, block_name)
         self.columns = columns
         self.output_col = output_col
         self.separator = separator

--- a/tests/test_filterblock.py
+++ b/tests/test_filterblock.py
@@ -8,17 +8,20 @@ from datasets import Dataset, Features, Value
 
 # First Party
 from instructlab.sdg.filterblock import FilterByValueBlock
+from instructlab.sdg.pipeline import PipelineContext
 
 
 class TestFilterByValueBlock(unittest.TestCase):
     def setUp(self):
         self.block = FilterByValueBlock(
+            PipelineContext(None, None, None, None),
             filter_column="age",
             filter_value=30,
             operation=operator.eq,
             convert_dtype=int,
         )
         self.block_with_list = FilterByValueBlock(
+            PipelineContext(None, None, None, None),
             filter_column="age",
             filter_value=[30, 35],
             operation=operator.eq,

--- a/tests/test_filterblock.py
+++ b/tests/test_filterblock.py
@@ -15,6 +15,7 @@ class TestFilterByValueBlock(unittest.TestCase):
     def setUp(self):
         self.block = FilterByValueBlock(
             PipelineContext(None, None, None, None),
+            block_name="filter_by_age",
             filter_column="age",
             filter_value=30,
             operation=operator.eq,
@@ -22,6 +23,7 @@ class TestFilterByValueBlock(unittest.TestCase):
         )
         self.block_with_list = FilterByValueBlock(
             PipelineContext(None, None, None, None),
+            block_name="filter_by_ages",
             filter_column="age",
             filter_value=[30, 35],
             operation=operator.eq,


### PR DESCRIPTION
This appears to be unused now - now pipeline definitions include it, and it's not used in LLMBlock anywhere.

This change might throw up cases where we're passing unknown configuration to LLMBlock. Here's why ...

It's hard to spot, but this:

```    
        def __init__(self, ..., **batch_kwargs):
            ...
            self.batch_params = batch_kwargs.get("batch_kwargs", {})
```
    
is equivalent to this:

```    
        def __init__(self, ..., **kwargs):
            ...
            self.batch_params = kwargs.get("batch_kwargs", {})
```
    
which is equivalent to this:

```    
        def __init__(self, ..., batch_kwargs={}, **kwargs):
            ...
            self.batch_params = batch_kwargs
```
    
except that trailing `**kwargs` meant we were silently accepting unknown block_config parameters.
    

