### PR TITLE
llmblock: Set a more reasonable default for num_tokens

### DIFF
--- a/src/instructlab/sdg/llmblock.py
+++ b/src/instructlab/sdg/llmblock.py
@@ -44,7 +44,7 @@ class LLMBlock(Block):
         self.defaults = {
             "model": self.model,
             "temperature": 0,
-            "max_tokens": 12000,
+            "max_tokens": 4096,
         }
 
     def _parse(self, generated_string) -> dict:


### PR DESCRIPTION

97cee87 llmblock: Set a more reasonable default for num_tokens

commit 97cee87606e7d04a8277dd315d30f9c8b4652cc7
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Jul 11 22:17:10 2024 -0400

    llmblock: Set a more reasonable default for num_tokens
    
    This parameter is part of the OpenAI API for creating a chat
    completion.
    
    https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens
    
    In our default flows, we configure many LLMBlocks explicitly to use
    `max_tokens` of 2048, but many do not have it set and rely on the
    default here.
    
    In some testing with vllm, it was observed that this caused a
    significant performance hit to vllm's cache. A value this high is
    unnecessary, as we have observed that most of our responses are closer
    to 2k, anyway.
    
    A follow-up to this would be to look closer at which blocks we are
    explicitly setting to use 2k, and which we are allowing to use the
    larger default. It's not clear to me if they are all intentional or
    not. Tracked via #126.
    
    This change originally comes from https://github.com/aakankshaduggal/sdg/pull/3/commits/04e33982dd8fba05f52700a9eedccdb115609e80
    
    Co-authored-by: shiv <shivchander.s30@gmail.com>
    Co-authored-by: Aakanksha Duggal <aduggal@redhat.com>
    Co-authored-by: Kai Xu <xuk@ibm.com>
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
