### PR TITLE
pipeline: Fail explicitly on an empty dataset

### DIFF
--- a/src/instructlab/sdg/pipeline.py
+++ b/src/instructlab/sdg/pipeline.py
@@ -14,6 +14,10 @@ from .logger_config import setup_logger
 logger = setup_logger(__name__)
 
 
+class EmptyDatasetError(Exception):
+    pass
+
+
 class PipelineContext:
     def __init__(
         self, client, model_family, model_id, num_instructions_to_generate
@@ -71,6 +75,12 @@ class Pipeline:
             logger.info(dataset)
 
             dataset = block.generate(dataset, **gen_kwargs)
+
+            # If at any point we end up with an empty data set, the pipeline has failed
+            if len(dataset) == 0:
+                raise EmptyDatasetError(
+                    f"Pipeline stopped: Empty dataset after running block: {block_name}"
+                )
 
             drop_columns_in_ds = [e for e in drop_columns if e in dataset.column_names]
             if drop_columns:

--- a/tests/test_default_pipeline_configs.py
+++ b/tests/test_default_pipeline_configs.py
@@ -28,6 +28,7 @@ def _noop_generate(self, samples, **gen_kwargs):
 @patch.object(SamplePopulatorBlock, "generate", _noop_generate)
 @patch.object(SelectorBlock, "generate", _noop_generate)
 @patch("instructlab.sdg.llmblock.server_supports_batched", lambda c, m: True)
+@patch.object(Pipeline, "_drop_duplicates", lambda self, dataset, cols: dataset)
 class TestDefaultPipelineConfigs(unittest.TestCase):
     def setUp(self):
         self._yaml_files = [
@@ -49,5 +50,5 @@ class TestDefaultPipelineConfigs(unittest.TestCase):
         )
         for pipeline_yaml in self._yaml_files:
             pipeline = Pipeline.from_file(ctx, pipeline_yaml)
-            output = pipeline.generate(Dataset.from_list([]))
+            output = pipeline.generate(Dataset.from_list([{"test": "test"}]))
             self.assertIsNotNone(output)


### PR DESCRIPTION
If at any point generate() on a block returns an empty dataset, this
is a failure condition. Go ahead and raise an exception right away in
that case.

This change was originally a subset of this commit: https://github.com/aakankshaduggal/sdg/pull/3/commits/256335e4a4f2e6f8642a6df279f16d9d85645445

Co-authored-by: shiv <shivchander.s30@gmail.com>
Co-authored-by: Aakanksha Duggal <aduggal@redhat.com>
Co-authored-by: Kai Xu <xuk@ibm.com>
Signed-off-by: Russell Bryant <rbryant@redhat.com>
