### PR TITLE
Update grounded_skills.yaml to add seed value

### DIFF
--- a/src/instructlab/sdg/pipelines/full/grounded_skills.yaml
+++ b/src/instructlab/sdg/pipelines/full/grounded_skills.yaml
@@ -10,6 +10,7 @@ blocks:
       temperature: 0.7
       max_tokens: 2048
       n: 10
+      seed: 42
     drop_duplicates:
       - context
   - name: gen_grounded_questions

--- a/src/instructlab/sdg/pipelines/schema/v1.json
+++ b/src/instructlab/sdg/pipelines/schema/v1.json
@@ -34,6 +34,7 @@
           },
           "gen_kwargs": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "model": {
                 "type": "string"
@@ -45,6 +46,9 @@
                 "type": "number"
               },
               "n": {
+                "type": "number"
+              },
+              "seed": {
                 "type": "number"
               },
               "extra_body": {


### PR DESCRIPTION
Resolves #108 

This commit adds seed parameter to gen_context block in the grounded skills flow.

What is a seed and why we need it?
Seed: This parameter is used to set a seed value for the random number generator used by the model. This allows you to generate reproducible results by providing the same seed value each time.

If seed is not provided, or the model changes, or the input changes (by as much as a single token) then the result will be a completely new result. It's only there for reproducibility.