### PR TITLE
ci: Run lint job if pipeline configs change

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ on:
       - 'tox.ini'
       - 'scripts/*.sh'
       - '.github/**'
+      - 'src/instructlab/sdg/pipelines/**'
   pull_request:
     branches:
       - "main"
@@ -25,6 +26,7 @@ on:
       - 'tox.ini'
       - 'scripts/*.sh'
       - '.github/**'
+      - 'src/instructlab/sdg/pipelines/**'
 
 env:
   PYTHON_VERSION: 3.11


### PR DESCRIPTION
The pipeline validation script runs as part of the lint workflow.
Update the workflow to config if the files under
`src/instructlab/sdg/pipelines/` change. Otherwise, a PR that only
changes a yaml file in this directory won't run this workflow.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
