### PR TITLE
Add `model_prompt` config param for LLMBlock

### DIFF
--- a/docs/pipeline_config.md
+++ b/docs/pipeline_config.md
@@ -1,0 +1,13 @@
+# Pipeline Configuration
+
+Built-in pipeline configurations can be found in [`src/instructlab/sdg/pipelines/`](../src/instructlab/sdg/pipelines/).
+
+## Pipeline Configuration Schema
+
+A schema for validating pipeline configuration can be found in [`src/instructlab/sdg/pipelines/schema/v1.json`](../src//instructlab/sdg/pipelines/schema/v1.json)
+
+## Version History
+
+| Version | Description |
+| ---     | --- |
+| 1.0     | Initial version |

--- a/src/instructlab/sdg/llmblock.py
+++ b/src/instructlab/sdg/llmblock.py
@@ -60,6 +60,7 @@ class LLMBlock(Block):
         block_name,
         config_path,
         output_cols,
+        model_prompt=None,
         parser_kwargs={},
         batch_kwargs={},
     ) -> None:
@@ -69,7 +70,11 @@ class LLMBlock(Block):
             """{system}\n{introduction}\n{principles}\n{examples}\n{generation}"""
         )
         self.prompt_template = self.prompt_struct.format(**self.block_config)
-        self.model_prompt = _get_model_prompt(self.ctx.model_family)
+        self.model_prompt = (
+            model_prompt
+            if model_prompt is not None
+            else _get_model_prompt(self.ctx.model_family)
+        )
         self.output_cols = output_cols
         self.batch_params = batch_kwargs
         self.parser_name = parser_kwargs.get("parser_name", None)
@@ -221,6 +226,7 @@ class ConditionalLLMBlock(LLMBlock):
         config_paths,
         output_cols,
         selector_column_name,
+        model_prompt=None,
         parser_kwargs={},
         batch_kwargs={},
     ) -> None:
@@ -230,6 +236,7 @@ class ConditionalLLMBlock(LLMBlock):
             block_name,
             config_paths[0][0],
             output_cols,
+            model_prompt=model_prompt,
             parser_kwargs=parser_kwargs,
             batch_kwargs=batch_kwargs,
         )

--- a/src/instructlab/sdg/pipelines/schema/v1.json
+++ b/src/instructlab/sdg/pipelines/schema/v1.json
@@ -126,6 +126,9 @@
                       "type": "string"
                     }
                   },
+                  "model_prompt": {
+                    "type": "string"
+                  },
                   "parser_kwargs": {
                     "type": "object",
                     "properties": {
@@ -170,6 +173,9 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "model_prompt": {
+                    "type": "string"
                   },
                   "selector_column_name": {
                     "type": "string"

--- a/tests/test_llmblock.py
+++ b/tests/test_llmblock.py
@@ -1,0 +1,57 @@
+# Standard
+from unittest.mock import MagicMock, patch
+import unittest
+
+# First Party
+from src.instructlab.sdg.llmblock import LLMBlock
+
+
+class TestLLMBlockModelPrompt(unittest.TestCase):
+    def setUp(self):
+        self.mock_ctx = MagicMock()
+        self.mock_ctx.model_family = "mixtral"
+        self.mock_ctx.model_id = "test_model"
+        self.mock_pipe = MagicMock()
+        self.config_return_value = {
+            "system": "system",
+            "introduction": "introduction",
+            "principles": "principles",
+            "examples": "examples",
+            "generation": "generation",
+        }
+
+    @patch("src.instructlab.sdg.block.Block._load_config")
+    def test_model_prompt_empty_string(self, mock_load_config):
+        mock_load_config.return_value = self.config_return_value
+        block = LLMBlock(
+            ctx=self.mock_ctx,
+            pipe=self.mock_pipe,
+            block_name="test_block",
+            config_path="",
+            output_cols=[],
+            model_prompt="",
+        )
+        self.assertEqual(
+            block.model_prompt,
+            "",
+            "model_prompt should be an empty string when explicitly set to an empty string",
+        )
+
+    @patch("src.instructlab.sdg.block.Block._load_config")
+    def test_model_prompt_none(self, mock_load_config):
+        mock_load_config.return_value = self.config_return_value
+        # Ensure that if a custom model_prompt is not specified, it defaults to setting it to
+        # something based on the model family. For this we just make sure it's not an empty string.
+        block = LLMBlock(
+            ctx=self.mock_ctx,
+            pipe=self.mock_pipe,
+            block_name="test_block",
+            config_path="",
+            output_cols=[],
+            model_prompt=None,  # Or simply omit model_prompt as it defaults to None
+        )
+        self.assertNotEqual(
+            block.model_prompt,
+            "",
+            "model_prompt should be a non-empty string when set to None",
+        )

--- a/tests/test_llmblock.py
+++ b/tests/test_llmblock.py
@@ -2,6 +2,9 @@
 from unittest.mock import MagicMock, patch
 import unittest
 
+# Third Party
+from datasets import Dataset, Features, Value
+
 # First Party
 from src.instructlab.sdg.llmblock import LLMBlock
 
@@ -13,16 +16,21 @@ class TestLLMBlockModelPrompt(unittest.TestCase):
         self.mock_ctx.model_id = "test_model"
         self.mock_pipe = MagicMock()
         self.config_return_value = {
-            "system": "system",
+            "system": "{fruit}",
             "introduction": "introduction",
             "principles": "principles",
             "examples": "examples",
             "generation": "generation",
         }
+        self.dataset = Dataset.from_dict(
+            {"fruit": ["apple", "pear", "mango"]},
+            features=Features({"fruit": Value("string")}),
+        )
 
     @patch("src.instructlab.sdg.block.Block._load_config")
     def test_model_prompt_empty_string(self, mock_load_config):
         mock_load_config.return_value = self.config_return_value
+        # Ensure that if an empty model_prompt is not specified, no model prompt is used.
         block = LLMBlock(
             ctx=self.mock_ctx,
             pipe=self.mock_pipe,
@@ -31,17 +39,18 @@ class TestLLMBlockModelPrompt(unittest.TestCase):
             output_cols=[],
             model_prompt="",
         )
+        prompt = block._format_prompt(self.dataset[0])
         self.assertEqual(
-            block.model_prompt,
-            "",
-            "model_prompt should be an empty string when explicitly set to an empty string",
+            prompt,
+            "apple\nintroduction\nprinciples\nexamples\ngeneration",
+            "no model prompt should be used when explicitly set to an empty string",
         )
 
     @patch("src.instructlab.sdg.block.Block._load_config")
     def test_model_prompt_none(self, mock_load_config):
         mock_load_config.return_value = self.config_return_value
         # Ensure that if a custom model_prompt is not specified, it defaults to setting it to
-        # something based on the model family. For this we just make sure it's not an empty string.
+        # something based on the model family (i.e. mixtral).
         block = LLMBlock(
             ctx=self.mock_ctx,
             pipe=self.mock_pipe,
@@ -50,8 +59,28 @@ class TestLLMBlockModelPrompt(unittest.TestCase):
             output_cols=[],
             model_prompt=None,  # Or simply omit model_prompt as it defaults to None
         )
-        self.assertNotEqual(
-            block.model_prompt,
-            "",
+        prompt = block._format_prompt(self.dataset[1])
+        self.assertEqual(
+            prompt,
+            "<s> [INST] pear\nintroduction\nprinciples\nexamples\ngeneration [/INST]",
+            "model_prompt based on model_family should be used set to None",
+        )
+
+    @patch("src.instructlab.sdg.block.Block._load_config")
+    def test_model_prompt_none(self, mock_load_config):
+        mock_load_config.return_value = self.config_return_value
+        # Ensure that if a custom model_prompt is specified, it is used correctly
+        block = LLMBlock(
+            ctx=self.mock_ctx,
+            pipe=self.mock_pipe,
+            block_name="test_block",
+            config_path="",
+            output_cols=[],
+            model_prompt="FOO {prompt} BAR",
+        )
+        prompt = block._format_prompt(self.dataset[1])
+        self.assertEqual(
+            prompt,
+            "FOO pear\nintroduction\nprinciples\nexamples\ngeneration BAR",
             "model_prompt should be a non-empty string when set to None",
         )


### PR DESCRIPTION
Closes #136 


2363dfe docs: Add a doc to track pipeline config version history
87871d3 llmblock: add `model_prompt` config parameter
4f042ae Add test case for LLMBlock model_prompt parameter
7045456 llmblock: allow model_prompt=""

commit 2363dfe57dfcc2e08f1d8128e86edf6d78822f9d
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Jul 15 14:35:26 2024 -0400

    docs: Add a doc to track pipeline config version history
    
    Our intiial pipeline configuration is version `1.0`. We haven't
    actually released anything yet, but I think it would be good to go
    ahead and get in the habit of managing this verison number as we make
    additions. Create a doc where we can keep a list of what changed at
    each version bump.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 87871d3d7b128fa12f7d073eb10b2f4401678115
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Jul 15 14:40:18 2024 -0400

    llmblock: add `model_prompt` config parameter
    
    We previously always set the model prompt based on the model family.
    We have some cases where we'd like to override this default behavior
    explicitly as part of pipeline configuration. This parameter will do
    that.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 4f042ae88cf98c8e2335a7ab898622dadcb2c009
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Jul 15 14:57:32 2024 -0400

    Add test case for LLMBlock model_prompt parameter
    
    Add a test case that ensures that passing `model_prompt` as an empty
    string results in `self.model_prompt` as empty. If this parameter is
    not specified (is None), `self.model_prompt` should be a non-empty
    string as a result of our default behavior of picking a prompt based
    on the model family.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 7045456420c94dfb8b576e5d77777ababf73d233
Author: Mark McLoughlin <markmc@redhat.com>
Date:   Mon Jul 15 23:56:10 2024 +0100

    llmblock: allow model_prompt=""
    
    An anticipated use case for model_prompt is simply to disable
    this additional prompt. Currently the pipeline author would
    need to specify model_prompt="{prompt}" to achieve this.
    
    Make this easier by allowing model_prompt="" to have this
    meaning
    
    Signed-off-by: Mark McLoughlin <markmc@redhat.com>
