### PR TITLE
Drop `__index_level_0__` columns 

### DIFF
--- a/src/instructlab/sdg/pipeline.py
+++ b/src/instructlab/sdg/pipeline.py
@@ -57,8 +57,9 @@ class Pipeline:
         Drop duplicates from the dataset based on the columns provided.
         """
         df = dataset.to_pandas()
-        df.drop_duplicates(subset=cols, inplace=True)
-        return Dataset.from_pandas(df)
+        df = df.drop_duplicates(subset=cols).reset_index(drop=True)
+        ds = Dataset.from_pandas(df)
+        return ds
 
     def generate(self, dataset) -> Dataset:
         """


### PR DESCRIPTION
resolves #109 


Dropping duplicate columns like` __index_level_0__`, this column gets added at different steps and cause redundancy and confusion due to the same key name. 


Dropping this key after `gen_questions` resolves the issue.