### PR TITLE
filterblock: add default_value for use with convert_dtype

### DIFF
--- a/src/instructlab/sdg/filterblock.py
+++ b/src/instructlab/sdg/filterblock.py
@@ -18,7 +18,7 @@ class FilterByValueBlockError(Exception):
 
 def _get_operator_func(op):
     if not op in dir(operator):
-        raise FilterByValueBlockError("Unknown FilterByValueBlock operation '{op}'")
+        raise FilterByValueBlockError(f"Unknown FilterByValueBlock operation '{op}'")
     return getattr(operator, op)
 
 
@@ -34,7 +34,7 @@ def _get_convert_dtype(convert_dtype):
 
     if not convert_dtype in type_mapping:
         raise FilterByValueBlockError(
-            "Unknown FilterByValueBlock convert_dtype '{convert_dtype}'"
+            f"Unknown FilterByValueBlock convert_dtype '{convert_dtype}'"
         )
 
     return type_mapping[convert_dtype]

--- a/src/instructlab/sdg/pipelines/schema/v1.json
+++ b/src/instructlab/sdg/pipelines/schema/v1.json
@@ -79,6 +79,9 @@
                     "type": "string",
                     "enum": ["float", "int", "bool"]
                   },
+                  "default_value": {
+                    "type": "string"
+                  },
                   "filter_column": {
                     "type": "string"
                   },

--- a/tests/test_filterblock.py
+++ b/tests/test_filterblock.py
@@ -1,5 +1,5 @@
 # Standard
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 import operator
 import unittest
 
@@ -39,16 +39,12 @@ class TestFilterByValueBlock(unittest.TestCase):
             features=Features({"age": Value("string")}),
         )
 
-    @patch("instructlab.sdg.filterblock.logger")
-    def test_generate_mixed_types(self, mock_logger):
+    def test_generate_mixed_types(self):
         filtered_dataset = self.block.generate(self.dataset)
         self.assertEqual(len(filtered_dataset), 1)
         self.assertEqual(filtered_dataset["age"], [30])
-        mock_logger.error.assert_called()
 
-    @patch("instructlab.sdg.filterblock.logger")
-    def test_generate_mixed_types_multi_value(self, mock_logger):
+    def test_generate_mixed_types_multi_value(self):
         filtered_dataset = self.block_with_list.generate(self.dataset)
         self.assertEqual(len(filtered_dataset), 2)
         self.assertEqual(filtered_dataset["age"], [30, 35])
-        mock_logger.error.assert_called()

--- a/tests/test_importblock.py
+++ b/tests/test_importblock.py
@@ -60,6 +60,7 @@ blocks:
     filter_value: 40
     operation: le
     convert_dtype: int
+    default_value: 1000
 - name: import_child
   type: ImportBlock
   config:


### PR DESCRIPTION
Fixes #133

We have been using None as a default value when dtype conversion fails. This works fine with the eq operator, but not others e.g. ge

In many cases a default like zero or False works fine, but there are cases where the pipeline author will need to specify a different default, for example when using something like `le(1)` you would want a default greater than 1.

With this change, we're acknowledging that this is default value handling is very normal, and we can drop from error logging to debug logging.