### PR TITLE
Set gen_kwargs['n'] dynamically in the simple pipelines

### DIFF
--- a/src/instructlab/sdg/pipelines/schema/v1.json
+++ b/src/instructlab/sdg/pipelines/schema/v1.json
@@ -46,7 +46,15 @@
                 "type": "number"
               },
               "n": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string",
+                    "enum": ["scaled"]
+                  }
+                ]
               },
               "seed": {
                 "type": "number"

--- a/src/instructlab/sdg/pipelines/simple/freeform_skills.yaml
+++ b/src/instructlab/sdg/pipelines/simple/freeform_skills.yaml
@@ -9,5 +9,6 @@ blocks:
     gen_kwargs:
       max_tokens: 2048
       temperature: 0.7
+      n: scaled
     drop_duplicates:
       - output

--- a/src/instructlab/sdg/pipelines/simple/grounded_skills.yaml
+++ b/src/instructlab/sdg/pipelines/simple/grounded_skills.yaml
@@ -9,6 +9,6 @@ blocks:
     gen_kwargs:
       max_tokens: 2048
       temperature: 0.7
-      n: 10
+      n: scaled
     drop_duplicates:
       - output

--- a/src/instructlab/sdg/pipelines/simple/knowledge.yaml
+++ b/src/instructlab/sdg/pipelines/simple/knowledge.yaml
@@ -9,5 +9,6 @@ blocks:
     gen_kwargs:
       max_tokens: 2048
       temperature: 0.7
+      n: scaled
     drop_duplicates:
     - output


### PR DESCRIPTION
We need a way to allow `--num-instructions` to influence how many
instructions we generate using the simple pipelines. The way to do
this seems to be to set `n` to this value. Since this is a runtime
parameter, and we only want to set it for `n` in certain cases, add a
new value for gen_kwargs['n'] called `dynamic` which is a hint to use
the runtime parameter here.

Closes #130

Signed-off-by: Russell Bryant <rbryant@redhat.com>
