### PR TITLE
Move `gen_kwargs` down to `LLMBlock`

### DIFF
--- a/src/instructlab/sdg/llmblock.py
+++ b/src/instructlab/sdg/llmblock.py
@@ -61,6 +61,7 @@ class LLMBlock(Block):
         config_path,
         output_cols,
         model_prompt=None,
+        gen_kwargs={},
         parser_kwargs={},
         batch_kwargs={},
     ) -> None:
@@ -76,12 +77,9 @@ class LLMBlock(Block):
         self.parser_name = parser_kwargs.get("parser_name", None)
         self.parsing_pattern = parser_kwargs.get("parsing_pattern", None)
         self.parser_cleanup_tags = parser_kwargs.get("parser_cleanup_tags", None)
-        self.defaults = {
-            "model": self.ctx.model_id,
-            "temperature": 0,
-            "max_tokens": 4096,
-        }
-
+        self.gen_kwargs = self._gen_kwargs(
+            gen_kwargs, model=self.ctx.model_id, temperature=0, max_tokens=4096
+        )
         # Whether the LLM server supports a list of input prompts
         # and supports the n parameter to generate n outputs per input
         self.server_supports_batched = server_supports_batched(
@@ -140,41 +138,39 @@ class LLMBlock(Block):
 
         return prompt if model_prompt is None else model_prompt.format(prompt=prompt)
 
-    def _gen_kwargs(self, **gen_kwargs):
-        gen_kwargs = {**self.defaults, **gen_kwargs}
+    def _gen_kwargs(self, gen_kwargs, **defaults):
+        gen_kwargs = {**defaults, **gen_kwargs}
+        if (
+            "n" in gen_kwargs
+            and isinstance(gen_kwargs["n"], str)
+            and gen_kwargs["n"] == "scaled"
+        ):
+            gen_kwargs["n"] = self.ctx.num_instructions_to_generate
         if "max_tokens" in gen_kwargs:
             gen_kwargs["max_tokens"] = int(gen_kwargs["max_tokens"])
         if "temperature" in gen_kwargs:
             gen_kwargs["temperature"] = float(gen_kwargs["temperature"])
-        gen_kwargs["n"] = self._get_n(gen_kwargs)
         return gen_kwargs
 
-    def _get_n(self, gen_kwargs):
-        n = gen_kwargs.get("n", 1)
-        if isinstance(n, str) and n == "scaled":
-            n = self.ctx.num_instructions_to_generate
-        return n
-
-    def _generate(self, samples, **gen_kwargs) -> list:
+    def _generate(self, samples) -> list:
         prompts = [self._format_prompt(sample) for sample in samples]
-        generate_args = self._gen_kwargs(**gen_kwargs)
 
         if self.server_supports_batched:
             response = self.ctx.client.completions.create(
-                prompt=prompts, **generate_args
+                prompt=prompts, **self.gen_kwargs
             )
             return [choice.text.strip() for choice in response.choices]
 
         results = []
         for prompt in prompts:
-            for _ in range(generate_args["n"]):
+            for _ in range(self.gen_kwargs.get("n", 1)):
                 response = self.ctx.client.completions.create(
-                    prompt=prompt, **generate_args
+                    prompt=prompt, **self.gen_kwargs
                 )
                 results.append(response.choices[0].text.strip())
         return results
 
-    def generate(self, samples: Dataset, **gen_kwargs) -> Dataset:
+    def generate(self, samples: Dataset) -> Dataset:
         """
         Generate the output from the block. This method should first validate the input data,
         then generate the output, and finally parse the generated output before returning it.
@@ -206,10 +202,10 @@ class LLMBlock(Block):
 
         # generate the output
 
-        outputs = self._generate(samples, **gen_kwargs)
+        outputs = self._generate(samples)
         logger.debug("Generated outputs: %s", outputs)
 
-        num_parallel_samples = self._get_n(gen_kwargs)
+        num_parallel_samples = self.gen_kwargs.get("n", 1)
         extended_samples = []
 
         # Duplicate each input sample n times, where n is the number

--- a/src/instructlab/sdg/pipeline.py
+++ b/src/instructlab/sdg/pipeline.py
@@ -67,14 +67,13 @@ class Pipeline:
             block_type = _lookup_block_type(block_prop["type"])
             block_config = block_prop["config"]
             drop_columns = block_prop.get("drop_columns", [])
-            gen_kwargs = block_prop.get("gen_kwargs", {})
             drop_duplicates_cols = block_prop.get("drop_duplicates", False)
             block = block_type(self.ctx, self, block_name, **block_config)
 
             logger.info("Running block: %s", block_name)
             logger.info(dataset)
 
-            dataset = block.generate(dataset, **gen_kwargs)
+            dataset = block.generate(dataset)
 
             # If at any point we end up with an empty data set, the pipeline has failed
             if len(dataset) == 0:

--- a/src/instructlab/sdg/pipelines/full/grounded_skills.yaml
+++ b/src/instructlab/sdg/pipelines/full/grounded_skills.yaml
@@ -6,11 +6,11 @@ blocks:
       config_path: ../../configs/skills/contexts.yaml
       output_cols:
         - context
-    gen_kwargs:
-      temperature: 0.7
-      max_tokens: 2048
-      n: 10
-      seed: 42
+      gen_kwargs:
+        temperature: 0.7
+        max_tokens: 2048
+        n: 10
+        seed: 42
     drop_duplicates:
       - context
   - name: gen_grounded_questions

--- a/src/instructlab/sdg/pipelines/full/knowledge.yaml
+++ b/src/instructlab/sdg/pipelines/full/knowledge.yaml
@@ -7,9 +7,9 @@ blocks:
       output_cols:
         - mmlubench_question
         - mmlubench_answer
-    gen_kwargs:
-      temperature: 0
-      max_tokens: 2048
+      gen_kwargs:
+        temperature: 0
+        max_tokens: 2048
     drop_duplicates:
       - mmlubench_question
   - name: gen_knowledge
@@ -24,8 +24,8 @@ blocks:
         parsing_pattern: '\[(?:Question|QUESTION)\]\s*(.*?)\s*\[(?:Answer|ANSWER)\]\s*(.*?)\s*(?=\[(?:Question|QUESTION)\]|$)'
         parser_cleanup_tags:
           - "[END]"
-    gen_kwargs:
-      max_tokens: 2048
+      gen_kwargs:
+        max_tokens: 2048
     drop_duplicates:
       - question
   - name: eval_faithfulness_qa_pair
@@ -35,8 +35,8 @@ blocks:
       output_cols:
         - explanation
         - judgment
-    gen_kwargs:
-      max_tokens: 2048
+      gen_kwargs:
+        max_tokens: 2048
   - name: filter_faithfulness
     type: FilterByValueBlock
     config:
@@ -53,8 +53,8 @@ blocks:
       output_cols:
         - feedback
         - score
-    gen_kwargs:
-      max_tokens: 2048
+      gen_kwargs:
+        max_tokens: 2048
   - name: filter_relevancy
     type: FilterByValueBlock
     config:
@@ -72,8 +72,8 @@ blocks:
       output_cols:
         - explanation
         - rating
-    gen_kwargs:
-      max_tokens: 2048
+      gen_kwargs:
+        max_tokens: 2048
   - name: filter_verify_question
     type: FilterByValueBlock
     config:

--- a/src/instructlab/sdg/pipelines/schema/v1.json
+++ b/src/instructlab/sdg/pipelines/schema/v1.json
@@ -32,38 +32,6 @@
               "type": "string"
             }
           },
-          "gen_kwargs": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "model": {
-                "type": "string"
-              },
-              "max_tokens": {
-                "type": "number"
-              },
-              "temperature": {
-                "type": "number"
-              },
-              "n": {
-                "oneOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "string",
-                    "enum": ["scaled"]
-                  }
-                ]
-              },
-              "seed": {
-                "type": "number"
-              },
-              "extra_body": {
-                "type": "object"
-              }
-            }
-          },
           "config": {
             "anyOf": [
               {
@@ -161,6 +129,38 @@
                         "type": "number"
                       }
                     }
+                  },
+                  "gen_kwargs": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "max_tokens": {
+                        "type": "number"
+                      },
+                      "temperature": {
+                        "type": "number"
+                      },
+                      "n": {
+                        "oneOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string",
+                            "enum": ["scaled"]
+                          }
+                        ]
+                      },
+                      "seed": {
+                        "type": "number"
+                      },
+                      "extra_body": {
+                        "type": "object"
+                      }
+                    }
                   }
                 }
               },
@@ -210,6 +210,38 @@
                     "properties": {
                       "num_samples": {
                         "type": "number"
+                      }
+                    }
+                  },
+                  "gen_kwargs": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "max_tokens": {
+                        "type": "number"
+                      },
+                      "temperature": {
+                        "type": "number"
+                      },
+                      "n": {
+                        "oneOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string",
+                            "enum": ["scaled"]
+                          }
+                        ]
+                      },
+                      "seed": {
+                        "type": "number"
+                      },
+                      "extra_body": {
+                        "type": "object"
                       }
                     }
                   }

--- a/src/instructlab/sdg/pipelines/simple/freeform_skills.yaml
+++ b/src/instructlab/sdg/pipelines/simple/freeform_skills.yaml
@@ -6,9 +6,9 @@ blocks:
       config_path: ../../configs/skills/simple_generate_qa_freeform.yaml
       output_cols:
         - output
-    gen_kwargs:
-      max_tokens: 2048
-      temperature: 0.7
-      n: scaled
+      gen_kwargs:
+        max_tokens: 2048
+        temperature: 0.7
+        n: scaled
     drop_duplicates:
       - output

--- a/src/instructlab/sdg/pipelines/simple/grounded_skills.yaml
+++ b/src/instructlab/sdg/pipelines/simple/grounded_skills.yaml
@@ -6,9 +6,9 @@ blocks:
       config_path: ../../configs/skills/simple_generate_qa_grounded.yaml
       output_cols:
         - output
-    gen_kwargs:
-      max_tokens: 2048
-      temperature: 0.7
-      n: scaled
+      gen_kwargs:
+        max_tokens: 2048
+        temperature: 0.7
+        n: scaled
     drop_duplicates:
       - output

--- a/src/instructlab/sdg/pipelines/simple/knowledge.yaml
+++ b/src/instructlab/sdg/pipelines/simple/knowledge.yaml
@@ -6,9 +6,9 @@ blocks:
       config_path: ../../configs/knowledge/simple_generate_qa.yaml
       output_cols:
       - output
-    gen_kwargs:
-      max_tokens: 2048
-      temperature: 0.7
-      n: scaled
+      gen_kwargs:
+        max_tokens: 2048
+        temperature: 0.7
+        n: scaled
     drop_duplicates:
     - output

--- a/tests/test_default_pipeline_configs.py
+++ b/tests/test_default_pipeline_configs.py
@@ -17,7 +17,7 @@ from instructlab.sdg.utilblocks import (
 )
 
 
-def _noop_generate(self, samples, **gen_kwargs):
+def _noop_generate(self, samples):
     return samples
 
 


### PR DESCRIPTION
Fixes #138

`gen_kwargs` is only used by `LLMBlock`, but that is not currently validated by the schema - it is accepted with any block type.

By moving it down a level, we clarify its role - it's basically arguments passed to `completions.create()`.