### PR TITLE
ci: run e2e on pipeline config related changes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,7 @@ on:
       - "release-**"
     paths:
       - '**.py'
+      - 'src/**.yaml'
       - 'pyproject.toml'
       - 'requirements*.txt'
       - '.github/workflows/e2e.yml'
@@ -18,6 +19,7 @@ on:
       - "release-**"
     paths:
       - '**.py'
+      - 'src/**.yaml'
       - 'pyproject.toml'
       - 'requirements*.txt'
       - '.github/workflows/e2e.yml'


### PR DESCRIPTION
I noticed that the e2e workflow did not run on #150. That PR only
changed some yaml files. When yaml files under `src/` change, we want
to run e2e, just like we do with python source changes.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
