### PR TITLE
Add v3 knowledge schema support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,6 +76,13 @@ jobs:
           # config contains DEFAULT_MODEL
           key: huggingface-${{ hashFiles('src/instructlab/configuration.py') }}
 
+      - name: Switch instructlab to PR 1790 (TEMPORARY)
+        run: |
+          cd instructlab
+          git fetch origin pull/1790/head:pr1790
+          git checkout pr1790
+          cd ..
+
       - name: Install instructlab and instructlab-sdg
         run: |
           export PATH="/home/runner/.local/bin:/usr/local/cuda/bin:$PATH"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,9 @@ httpx>=0.25.0,<1.0.0
 langchain-text-splitters
 openai>=1.13.3,<2.0.0
 platformdirs>=4.2
-# Note: this dependency goes along with langchain-text-splitters and mayt be
+# Note: this dependency goes along with langchain-text-splitters and may be
 #       removed once that one is removed.
 # do not use 8.4.0 due to a bug in the library
 # https://github.com/instructlab/instructlab/issues/1389
 tenacity>=8.3.0,!=8.4.0
+instructlab-schema>=0.3.1

--- a/src/instructlab/sdg/configs/knowledge/generate_questions_responses.yaml
+++ b/src/instructlab/sdg/configs/knowledge/generate_questions_responses.yaml
@@ -27,24 +27,9 @@ principles: |
 examples: |
   Here are some examples of questions:
 
-  [QUESTION]
-  Explain the process of photosynthesis in plants. Include in your answer the roles of chlorophyll, light, water, and carbon dioxide, and describe how oxygen and glucose are produced.
-  [ANSWER]
-  Photosynthesis is the process by which plants, algae, and some bacteria use sunlight to synthesize food from carbon dioxide and water. Photosynthesis in plants primarily occurs in the leaves, specifically in the chloroplasts. Chlorophyll, the green pigment in chloroplasts, absorbs light energy, which is then used to convert carbon dioxide (from the air) and water (from the soil) into glucose, a simple sugar. This process also releases oxygen as a byproduct. Light energy splits water molecules, releasing electrons and hydrogen ions and forming oxygen. The light-dependent reactions convert light energy into chemical energy (ATP and NADPH), which is used in the light-independent reactions (Calvin cycle) to convert carbon dioxide into glucose. The overall result is the conversion of solar energy into chemical energy in the form of glucose, which plants use for growth and development.
-  [END]
+  [Document]
+  {icl_document}
 
-  [QUESTION]
-  In a study on the effects of temperature on enzyme activity, an enzyme exhibited its highest activity at 37°C. At both higher and lower temperatures, its activity decreased. Based on this information, which of the following best explains the enzyme's behavior?
-  Options:
-  a) Enzymes are temperature-sensitive and can denature at high temperatures, losing their functional shape, while at low temperatures, their reaction rates decrease due to reduced molecular motion.
-  b) Enzymes are more effective at higher temperatures as increased heat provides more energy for reactions, and lower temperatures cause enzymes to become more active due to enhanced molecular stability.
-  c) The enzyme's behavior is unrelated to temperature; instead, it is likely due to changes in pH levels, which affect enzyme activity.
-  d) All enzymes universally work best at exactly 37°C, as this is the standard temperature for all biochemical reactions in nature.
-  [ANSWER]
-  a) Enzymes are temperature-sensitive and can denature at high temperatures, losing their functional shape, while at low temperatures, their reaction rates decrease due to reduced molecular motion.
-  [END]
-
-  For this {domain} domain here are some sample questions:
   [QUESTION]
   {icl_query_1}
   [ANSWER]
@@ -65,4 +50,7 @@ examples: |
 
 generation: |
   Here is the document:
+
+  [DOCUMENT]
+  {document_outline}
   {document}

--- a/src/instructlab/sdg/configs/knowledge/simple_generate_qa.yaml
+++ b/src/instructlab/sdg/configs/knowledge/simple_generate_qa.yaml
@@ -13,6 +13,9 @@ principles: |
   7. The output should be an appropriate response to the input and the instruction. Long outputs are preferable.
 
 examples: |
+  Here is a sample section of the document as an example:
+  {icl_document}
+
   Here are some examples to help you understand the type of questions that are asked for this document:
 
   {icl_query_1}
@@ -25,6 +28,8 @@ examples: |
   {icl_response_3}
 
   Here is the document:
+
+  {document_outline}
   {document}
 
 generation: |

--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -139,6 +139,20 @@ def _gen_train_data(
             outfile.write("\n")
 
 
+def _knowledge_seed_example_to_test_data(seed_example):
+    res = []
+    for qna in seed_example["questions_and_answers"]:
+        user = qna["question"] + "\n" + seed_example["input"]  # context
+        res.append(
+            {
+                "system": _SYS_PROMPT,
+                "user": _unescape(user),
+                "assistant": _unescape(qna["answer"]),
+            }
+        )
+    return res
+
+
 def _gen_test_data(
     leaf_nodes,
     output_file_test,
@@ -146,6 +160,12 @@ def _gen_test_data(
     test_data = []
     for _, leaf_node in leaf_nodes.items():
         for seed_example in leaf_node:
+            if "questions_and_answers" in seed_example:
+                test_data.extend(_knowledge_seed_example_to_test_data(seed_example))
+                continue
+
+            # skill seed example
+
             user = seed_example["instruction"]  # question
 
             if len(seed_example["input"]) > 0:

--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -142,7 +142,7 @@ def _gen_train_data(
 def _knowledge_seed_example_to_test_data(seed_example):
     res = []
     for qna in seed_example["questions_and_answers"]:
-        user = qna["question"] + "\n" + seed_example["input"]  # context
+        user = qna["question"] + "\n" + seed_example["context"]
         res.append(
             {
                 "system": _SYS_PROMPT,

--- a/src/instructlab/sdg/utils/taxonomy.py
+++ b/src/instructlab/sdg/utils/taxonomy.py
@@ -335,7 +335,7 @@ def _read_taxonomy_file(file_path: str, yaml_rules: Optional[str] = None):
 
         # get seed instruction data
         tax_path = "->".join(taxonomy_path.parent.parts)
-        task_description = contents.get("task_description")
+        task_description = contents.get("task_description", None)
         domain = contents.get("domain")
         documents = contents.get("document")
         if documents:
@@ -343,20 +343,34 @@ def _read_taxonomy_file(file_path: str, yaml_rules: Optional[str] = None):
             logger.debug("Content from git repo fetched")
 
         for seed_example in contents.get("seed_examples"):
-            question = seed_example.get("question")
-            answer = seed_example.get("answer")
             context = seed_example.get("context", "")
-            seed_instruction_data.append(
-                {
-                    "instruction": question,
-                    "input": context,
-                    "output": answer,
-                    "taxonomy_path": tax_path,
-                    "task_description": task_description,
-                    "document": documents,
-                    "domain": domain,
-                }
-            )
+            if "questions_and_answers" in seed_example:
+                question_answer_list = seed_example.get("questions_and_answers")
+                seed_instruction_data.append(
+                    {
+                        "questions_and_answers": question_answer_list,
+                        "input": context,
+                        "taxonomy_path": tax_path,
+                        "document": documents,
+                        "domain": domain,
+                        "document_outline": contents.get("document_outline"),
+                    }
+                )
+            else:
+                question = seed_example.get("question")
+                answer = seed_example.get("answer")
+
+                seed_instruction_data.append(
+                    {
+                        "instruction": question,
+                        "input": context,
+                        "output": answer,
+                        "taxonomy_path": tax_path,
+                        "task_description": task_description,
+                        "document": documents,
+                        "domain": domain,
+                    }
+                )
     except Exception as e:
         errors += 1
         raise TaxonomyReadingException(f"Exception {e} raised in {file_path}") from e
@@ -418,8 +432,7 @@ def read_taxonomy_leaf_nodes(taxonomy, taxonomy_base, yaml_rules):
 
 
 def _knowledge_leaf_node_to_samples(leaf_node, server_ctx_size, chunk_word_count):
-    samples = [{}]
-
+    samples = []
     # document is the same for the whole leaf node
     chunks = (
         chunking.chunk_document(
@@ -436,38 +449,24 @@ def _knowledge_leaf_node_to_samples(leaf_node, server_ctx_size, chunk_word_count
 
     for chunk in chunks:
         # pylint: disable=consider-using-enumerate
-        for i in range(len(leaf_node)):
-            samples[-1].setdefault("task_description", leaf_node[i]["task_description"])
-            samples[-1].setdefault("domain", domain)
-            samples[-1].setdefault("document", chunk)
-            if samples[-1].get("document") and not samples[-1].get("domain"):
-                raise utils.GenerateException(
-                    "Error: No domain provided for knowledge document in leaf node"
-                )
-            if "icl_query_3" in samples[-1]:
-                samples.append({})
-            if "icl_query_1" not in samples[-1]:
-                samples[-1]["icl_query_1"] = leaf_node[i]["instruction"]
-                samples[-1]["icl_response_1"] = leaf_node[i]["output"]
-            elif "icl_query_2" not in samples[-1]:
-                samples[-1]["icl_query_2"] = leaf_node[i]["instruction"]
-                samples[-1]["icl_response_2"] = leaf_node[i]["output"]
-            else:
-                samples[-1]["icl_query_3"] = leaf_node[i]["instruction"]
-                samples[-1]["icl_response_3"] = leaf_node[i]["output"]
-
-        # wrap back around to the beginning if the number of examples was not
-        # evenly divisble by 3
-        if "icl_query_2" not in samples[-1]:
-            samples[-1]["icl_query_2"] = leaf_node[0]["instruction"]
-            samples[-1]["icl_response_2"] = leaf_node[0]["output"]
-        if "icl_query_3" not in samples[-1]:
-            samples[-1]["icl_query_3"] = leaf_node[1 if len(leaf_node) > 1 else 0][
-                "instruction"
-            ]
-            samples[-1]["icl_response_3"] = leaf_node[1 if len(leaf_node) > 1 else 0][
-                "output"
-            ]
+        for icl_ in leaf_node:
+            icl_query = {
+                f"icl_query_{idx+1}": val["question"]
+                for idx, val in enumerate(icl_["questions_and_answers"])
+            }
+            icl_resp = {
+                f"icl_response_{idx+1}": val["answer"]
+                for idx, val in enumerate(icl_["questions_and_answers"])
+            }
+            samples_row = {
+                "icl_document": icl_["input"],
+                "document": chunk,
+                "document_outline": icl_["document_outline"],
+                "domain": domain,
+            }
+            samples_row.update(icl_query)
+            samples_row.update(icl_resp)
+            samples.append(samples_row)
 
     return samples
 

--- a/src/instructlab/sdg/utils/taxonomy.py
+++ b/src/instructlab/sdg/utils/taxonomy.py
@@ -18,7 +18,6 @@ import gitdb
 import yaml
 
 # First Party
-from instructlab.sdg import utils
 from instructlab.sdg.utils import chunking
 
 logger = logging.getLogger(__name__)

--- a/src/instructlab/sdg/utils/taxonomy.py
+++ b/src/instructlab/sdg/utils/taxonomy.py
@@ -22,6 +22,8 @@ from instructlab.sdg.utils import chunking
 
 logger = logging.getLogger(__name__)
 
+MIN_KNOWLEDGE_VERSION = 3
+
 DEFAULT_YAML_RULES = """\
 extends: relaxed
 
@@ -200,6 +202,13 @@ def _validate_yaml(contents: Mapping[str, Any], taxonomy_path: Path) -> int:
         logger.info(
             f"Cannot determine schema name from path {taxonomy_path}. Using {schema_name} schema."
         )
+
+    if schema_name == "knowledge" and version < MIN_KNOWLEDGE_VERSION:
+        logger.error(
+            f"Version {version} is not supported for knowledge taxonomy. Minimum supported version is {MIN_KNOWLEDGE_VERSION}."
+        )
+        errors += 1
+        return errors
 
     try:
         schema_resource = retrieve(f"{schema_name}.json")

--- a/src/instructlab/sdg/utils/taxonomy.py
+++ b/src/instructlab/sdg/utils/taxonomy.py
@@ -357,7 +357,7 @@ def _read_taxonomy_file(file_path: str, yaml_rules: Optional[str] = None):
                 seed_instruction_data.append(
                     {
                         "questions_and_answers": question_answer_list,
-                        "input": context,
+                        "context": context,
                         "taxonomy_path": tax_path,
                         "document": documents,
                         "domain": domain,
@@ -467,7 +467,7 @@ def _knowledge_leaf_node_to_samples(leaf_node, server_ctx_size, chunk_word_count
                 for idx, val in enumerate(icl_["questions_and_answers"])
             }
             samples_row = {
-                "icl_document": icl_["input"],
+                "icl_document": icl_["context"],
                 "document": chunk,
                 "document_outline": icl_["document_outline"],
                 "domain": domain,


### PR DESCRIPTION
This PR includes the changes necessary to move to the v3 schema version for
knowledge taxonomy files.

See epic #160 for more information.

b4e8bf1 full: Adjust knowledge prompt for v3 schema
33abe1e simple: Adapt simple knowledge pipeline for v3 schema
94a7a5e utils: Update taxonomy reading code to handle knowledge v3
aaf0283 requirements: use schema version that includes v3
7d56e88 utils: drop an unused import
b228f3f e2e: Temporarily install instructlab from a PR
c83220a generate_data: Account for knowledge format when generating test data
5eac452 Report error if knowledge taxonomy version is < 3

commit b4e8bf1398c36b2d70c4d862c0ff203221d1c892
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jul 17 17:48:53 2024 -0400

    full: Adjust knowledge prompt for v3 schema
    
    For more information on the v3 schema, see this issue:
    
      https://github.com/instructlab/sdg/issues/160
    
    This change to the prompt does a couple of important things:
    
    - Make use of document-specific context for the provided sample q&a.
    
    - Add the new `document_outline` field which provides a summary of the
      document.
    
    Co-authored-by: abhi1092 <abhi1092@gmail.com>
    Co-authored-by: shiv <shivchander.s30@gmail.com>
    Co-authored-by: Aakanksha Duggal <aduggal@redhat.com>
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 33abe1eca530c45a1d72e1e76304ec0388f6131e
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jul 17 19:19:07 2024 -0400

    simple: Adapt simple knowledge pipeline for v3 schema
    
    The v3 knowledge schema includes context specific to the sample
    questionsa nd answers. Include that context in the prompt.
    
    The schema also includes a new `document_outline`. Give it prior to
    the document chunk in the same way as the `full` pipeline prompt,
    `generate_questions_responses.yaml`.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 94a7a5e0a8a36e56a8ca09922f028ab6ec203903
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Jul 18 15:30:16 2024 -0400

    utils: Update taxonomy reading code to handle knowledge v3
    
    This is part of https://github.com/instructlab/sdg/issues/160
    
    The changes here originated from https://github.com/aakankshaduggal/sdg/commit/5baf6dfde8334fa52a4ffe38e9dc9121dfb468aa
    
    There are two major changes here.
    
    - When parsing a `qna.yaml` file from a taxonomy tree, adjust for the
      new schema for knowledge. There is no attempt to maintain
      compatibility with prior versions of the schema (v1, v2).
    
    - Change how we translate the taxonomy data into the dataset sent into
      the pipeline as input. Instead of implementing a sliding window
      approach of 3 sample qna pairs at a time over all chunks of the
      document, we now create a row per seed_example (context and
      associated qna pairs) for each chunk of knowledge docs.
    
    Co-authored-by: abhi1092 <abhi1092@gmail.com>
    Co-authored-by: shiv <shivchander.s30@gmail.com>
    Co-authored-by: Aakanksha Duggal <aduggal@redhat.com>
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit aaf02837650ba48769c3e7bc722b52227de4ff23
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Jul 18 15:37:43 2024 -0400

    requirements: use schema version that includes v3
    
    instructlab-schema 0.3.1 includes the v3 schema for knowledge that is
    now required.
    
    Fix a typo in a comment in this file while we're at it.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 7d56e88f0311f552fbc4e682d738a2f0e1bd4515
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Jul 18 16:15:25 2024 -0400

    utils: drop an unused import
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit b228f3fd680cabe5febcbd940f3c94b4c7162b85
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Jul 18 16:28:11 2024 -0400

    e2e: Temporarily install instructlab from a PR
    
    This PR includes the changes to account for schema v3.
    This should be removed later.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit c83220a82188f2a3085526861c0bb380ba7b6794
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Jul 19 14:10:54 2024 -0400

    generate_data: Account for knowledge format when generating test data
    
    _gen_test_data() needed fixes to account for the different format
    coming from a knowledge doc vs skills.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 5eac452005ba455e771a82a02729bdf163cc0311
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Jul 22 17:38:09 2024 -0400

    Report error if knowledge taxonomy version is < 3
    
    We no longer support versions 1 and 2, so detect and give a clear
    error message when this occurs.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
