### PR TITLE
Load custom pipelines from shared data dir

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ click>=8.1.7,<9.0.0
 httpx>=0.25.0,<1.0.0
 langchain-text-splitters
 openai>=1.13.3,<2.0.0
+platformdirs>=4.2
 # Note: this dependency goes along with langchain-text-splitters and mayt be
 #       removed once that one is removed.
 # do not use 8.4.0 due to a bug in the library

--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -186,7 +186,9 @@ def _sdg_init(pipeline, client, model_family, model_id, num_instructions_to_gene
 
     def load_pipeline(yaml_basename):
         if pipeline_pkg:
-            with resources.path(pipeline_pkg, yaml_basename) as yaml_path:
+            with resources.as_file(
+                resources.files(pipeline_pkg).joinpath(yaml_basename)
+            ) as yaml_path:
                 return Pipeline.from_file(ctx, yaml_path)
         else:
             return Pipeline.from_file(ctx, os.path.join(pipeline, yaml_basename))


### PR DESCRIPTION
Allow convenient aliases to be defined for custom pipelines, to be loaded from a well known predefined directory.

Related #154