### PR TITLE
Generate data for model evaluation using the MMLU benchmark

### DIFF
--- a/src/instructlab/sdg/eval_data.py
+++ b/src/instructlab/sdg/eval_data.py
@@ -1,0 +1,133 @@
+# Standard
+from importlib import resources
+from typing import Any
+import re
+
+# Third Party
+from datasets import Dataset
+import yaml
+
+# First Party
+from instructlab.sdg.pipeline import EVAL_PIPELINES_PKG, Pipeline
+
+# Local
+from .logger_config import setup_logger
+
+logger = setup_logger(__name__)
+
+
+def _extract_options(text: str) -> list[Any]:
+    """regex to extract options from mcq
+
+    Args:
+        text (str): question with options/mcq choices
+
+    Returns:
+        list[Any]: options under question that match the pattern.
+    """
+    # Use a regular expression to find patterns and capture the text after the letter and parenthesis
+    pattern = r"\b[A-Z]\) (.+)"
+    matches = re.findall(pattern, text)
+    return matches
+
+
+def _format_mmlu_style(ds: Dataset) -> Dataset:
+    """Format the dataset according to lm-harness mmlu requirement.
+
+    Args:
+        ds (Dataset): input dataset
+
+    Returns:
+        Dataset: formated hf dataset
+    """
+    ds = ds.map(
+        lambda x: {"answer": x["mmlubench_answer"][: x["mmlubench_answer"].index(")")]}
+    )
+    ds = ds.map(lambda x: {"choices": _extract_options(x["mmlubench_question"])})
+    ds = ds.map(
+        lambda x: {
+            "question": x["mmlubench_question"][
+                : x["mmlubench_question"].index("A)")
+            ].strip()
+        }
+    )
+    ds = ds.rename_columns({"domain": "subject"})
+    ds = ds.filter(lambda x: x["choices"])
+    ds = ds.filter(lambda x: len(x["choices"]) == 4)
+    ds = ds.filter(lambda x: x["answer"] in ["A", "B", "C", "D"])
+    ds = ds.class_encode_column("answer")
+    return ds
+
+
+def _post_process_mcq(ds: Dataset) -> Dataset:
+    """Filter, format and return Multiple Choice Question (MCQ) dataset that
+    is compatible with lm-harness for doing mmlu-style evaluation
+
+    Filters out badly generated data, adds dataset type column
+
+    Args:
+        ds (Dataset): mcq generated dataset from mmmlu pipeline
+
+    Returns:
+        Dataset: Hf Dataset with new column, filtered dataset
+    """
+    ds = ds.filter(lambda x: ")" in x["mmlubench_answer"])
+    ds = ds.filter(lambda x: "A)" in x["mmlubench_question"])
+    ds = ds.add_column("dataset_type", ["mcq_qa"] * ds.num_rows)
+    return _format_mmlu_style(ds)
+
+
+def _create_mmlu_evaluation_task(task_name, eval_data_file_path, yaml_file_path):
+    """
+    Prepare Task Yaml that will be used in by the instructlab.sdg library using lm_eval_harness to evaluate knowledge using mmlu style metric
+    see: https://github.com/EleutherAI/lm-evaluation-harness/blob/main/docs/new_task_guide.md
+         https://github.com/EleutherAI/lm-evaluation-harness/blob/main/docs/new_task_guide.md#writing-a-prompt-template
+    """
+
+    # The features we know to be required are question, choices, and answer
+    # TODO: Remove excess features its more clear what isn't required
+    task_yaml = {
+        "task": task_name,
+        "dataset_path": "json",
+        "dataset_name": None,
+        "test_split": "test",
+        "doc_to_text": "{{question.strip()}}\nA. {{choices[0]}}\nB. {{choices[1]}}\nC. {{choices[2]}}\nD. {{choices[3]}}\nAnswer:",
+        "doc_to_choice": "{{[choices[0], choices[1], choices[2], choices[3]]}}",
+        "doc_to_target": "{{answer}}",
+        "output_type": "multiple_choice",
+        "metric_list": {
+            "metric": "acc",
+            "aggregation": "mean",
+            "higher_is_better": "true",
+        },
+        "dataset_kwargs": {"data_files": {"test": eval_data_file_path}},
+        "group": "mmlu_pr",
+    }
+    with open(yaml_file_path, "w", encoding="utf-8") as yaml_file:
+        yaml.dump(task_yaml, yaml_file, default_flow_style=False)
+
+
+def generate_eval_task_data(
+    mmlubench_pipe, task_name, samples, output_dir, date_suffix
+):
+    mmlubench_data = mmlubench_pipe.generate(samples)
+    mmlubench_data = _post_process_mcq(mmlubench_data)
+
+    eval_data_file_path = f"{output_dir}/node_datasets_{date_suffix}/mmlubench_{date_suffix}_{task_name}.jsonl"
+    logger.info(f"Saving MMLU Dataset {eval_data_file_path}")
+    mmlubench_data.to_json(eval_data_file_path, orient="records", lines=True)
+
+    yaml_file_path = f"{output_dir}/node_datasets_{date_suffix}/{task_name}_{date_suffix}_{task_name}_task.yaml"
+    logger.info(f"Saving MMLU Task yaml {yaml_file_path}")
+    _create_mmlu_evaluation_task(
+        task_name=task_name,
+        eval_data_file_path=eval_data_file_path,
+        yaml_file_path=yaml_file_path,
+    )
+
+
+def mmlubench_pipe_init(ctx):
+    with resources.as_file(
+        resources.files(EVAL_PIPELINES_PKG).joinpath("mmlu_bench.yaml")
+    ) as yaml_path:
+        return Pipeline.from_file(ctx, yaml_path)

--- a/src/instructlab/sdg/pipeline.py
+++ b/src/instructlab/sdg/pipeline.py
@@ -281,3 +281,4 @@ def _parse_pipeline_config_file(pipeline_yaml):
 # This is part of the public API.
 SIMPLE_PIPELINES_PACKAGE = "instructlab.sdg.pipelines.simple"
 FULL_PIPELINES_PACKAGE = "instructlab.sdg.pipelines.full"
+EVAL_PIPELINES_PKG = "instructlab.sdg.pipelines.eval"

--- a/src/instructlab/sdg/pipelines/eval/mmlu_bench.yaml
+++ b/src/instructlab/sdg/pipelines/eval/mmlu_bench.yaml
@@ -1,0 +1,14 @@
+version: "1.0"
+blocks:
+  - name: gen_mmlu_knowledge
+    type: LLMBlock
+    config:
+      config_path: ../../configs/knowledge/mcq_generation.yaml
+      output_cols:
+        - mmlubench_question
+        - mmlubench_answer
+      gen_kwargs:
+        temperature: 0.7
+        max_tokens: 2048
+    drop_duplicates:
+      - mmlubench_question

--- a/src/instructlab/sdg/pipelines/full/knowledge.yaml
+++ b/src/instructlab/sdg/pipelines/full/knowledge.yaml
@@ -1,17 +1,5 @@
 version: "1.0"
 blocks:
-  - name: gen_mmlu_knowledge
-    type: LLMBlock
-    config:
-      config_path: ../../configs/knowledge/mcq_generation.yaml
-      output_cols:
-        - mmlubench_question
-        - mmlubench_answer
-      gen_kwargs:
-        temperature: 0
-        max_tokens: 2048
-    drop_duplicates:
-      - mmlubench_question
   - name: gen_knowledge
     type: LLMBlock
     config:

--- a/tests/test_generate_data.py
+++ b/tests/test_generate_data.py
@@ -22,7 +22,7 @@ def test_sdg_init_batch_size_optional():
         1,
         batch_size=None,
         batch_num_workers=None,
-    )
+    )[1:]
     assert all(
         pipe.ctx.batch_size == PipelineContext.DEFAULT_BATCH_SIZE
         for sdg in sdgs
@@ -40,5 +40,5 @@ def test_sdg_init_batch_size_optional():
         1,
         batch_size=20,
         batch_num_workers=32,
-    )
+    )[1:]
     assert all(pipe.ctx.batch_size == 20 for sdg in sdgs for pipe in sdg.pipelines)

--- a/tests/test_generate_data.py
+++ b/tests/test_generate_data.py
@@ -6,39 +6,33 @@ Unit tests for the top-level generate_data module.
 from unittest import mock
 
 # First Party
-from instructlab.sdg.generate_data import _sdg_init
+from instructlab.sdg.generate_data import _context_init
 from instructlab.sdg.pipeline import PipelineContext
 
 
-def test_sdg_init_batch_size_optional():
-    """Test that the _sdg_init function can handle a missing batch size by
+def test_context_init_batch_size_optional():
+    """Test that the _context_init function can handle a missing batch size by
     delegating to the default in PipelineContext.
     """
-    sdgs = _sdg_init(
-        "simple",
+    ctx = _context_init(
         None,
         "mixtral",
         "foo.bar",
         1,
         batch_size=None,
         batch_num_workers=None,
-    )[1:]
-    assert all(
-        pipe.ctx.batch_size == PipelineContext.DEFAULT_BATCH_SIZE
-        for sdg in sdgs
-        for pipe in sdg.pipelines
     )
+    assert ctx.batch_size == PipelineContext.DEFAULT_BATCH_SIZE
 
 
-def test_sdg_init_batch_size_optional():
-    """Test that the _sdg_init function can handle a passed batch size"""
-    sdgs = _sdg_init(
-        "simple",
+def test_context_init_batch_size_optional():
+    """Test that the _context_init function can handle a passed batch size"""
+    ctx = _context_init(
         None,
         "mixtral",
         "foo.bar",
         1,
         batch_size=20,
         batch_num_workers=32,
-    )[1:]
-    assert all(pipe.ctx.batch_size == 20 for sdg in sdgs for pipe in sdg.pipelines)
+    )
+    assert ctx.batch_size == 20


### PR DESCRIPTION
commit d280df97196fd6a4af3f37132fc360d74c78ad42
    Generate mmlubench data
    
    Rebased from
    https://github.com/aakankshaduggal/sdg/pull/15 and
    https://github.com/aakankshaduggal/sdg/pull/16
    
    Changed by me (synth data wasn't the correct format without it(merlinite-7b-lab))
    src/instructlab/sdg/pipelines/simple/mmlu_bench.yaml
    -        temperature: 0
    +        temperature: 0.7
    
    Refactor MMLU bench code into eval_data.py
    
    The MMLU bench pipeline is different from the training samples
    generation pipeline - instead it is generating a dataset that
    can be used to evaluate the model performance.
    
    Let's assume there could be multiple eval sdg pipelines in future,
    and they could be used with any of the training data pipelines,
    so put mmlu_bench.yaml in instructlab.sdg.pipelines.eval.
    
    Also encapsulate all the relevant code into a new sdg.eval_data
    Python module whose main interface is:
    
    ```
    mmlu_bench_pipe = eval_data.mmlubench_pipe_init(ctx)
    
    eval_data.generate_eval_task_data(mmlu_bench_pipe, task_name, samples, ...)
    ```
    
    Closes: #170
    
    Co-authored-by: shiv <shivchander.s30@gmail.com>
    Co-authored-by: abhi1092 <abhi1092@gmail.com>
    Co-authored-by: Aakanksha Duggal <aduggal@redhat.com>
    Co-authored-by: Mark McLoughlin <markmc@redhat.com>
    
    Signed-off-by: Derek Higgins <derekh@redhat.com>

commit 54c113ab79fcdc0f0c18049d073ea2814659df68 (HEAD -> main, me/mmlubench)
    sdg_init() refactor - take a PipelineContext rather than returning one
    
    This makes more sense if we want to use PipelineContext to separately
    initialize the mmlu-bench pipeline.
    
    Suggestion from @bbrowning in #163.
    
    Signed-off-by: Mark McLoughlin <markmc@redhat.com>

