### PR TITLE
Move Block._validate to llmblock

### DIFF
--- a/src/instructlab/sdg/block.py
+++ b/src/instructlab/sdg/block.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from abc import ABC
-from collections import ChainMap
 from typing import Any, Dict, Union
 import os.path
 
@@ -20,26 +19,6 @@ class Block(ABC):
         self.ctx = ctx
         self.pipe = pipe
         self.block_name = block_name
-
-    @staticmethod
-    def _validate(prompt_template: str, input_dict: Dict[str, Any]) -> bool:
-        """
-        Validate the input data for this block. This method should be implemented by subclasses
-        to define how the block validates its input data.
-
-        :return: True if the input data is valid, False otherwise.
-        """
-
-        class Default(dict):
-            def __missing__(self, key: str) -> None:
-                raise KeyError(key)
-
-        try:
-            prompt_template.format_map(ChainMap(input_dict, Default()))
-            return True
-        except KeyError as e:
-            logger.error("Missing key: {}".format(e))
-            return False
 
     def _load_config(self, config_path: str) -> Union[Dict[str, Any], None]:
         """


### PR DESCRIPTION
The custom "validate" function in ConditionalLLMBlock wasn't
being called and renaming it "_validate" is problematic as its
static. Instead move it to LLMBlock and change it to a instance
method as only LLMBlock uses it.
    
Closes #186
    
Co-authored-by: abhi1092 <Abhi.b@ibm.com>
