### PR TITLE
Update the v1 pipeline schema to include new pipeline blocks

### DIFF
--- a/src/instructlab/sdg/pipelines/schema/v1.json
+++ b/src/instructlab/sdg/pipelines/schema/v1.json
@@ -303,6 +303,59 @@
                     }
                   }
                 }
+              },
+              {
+                "type": "object",
+                "description": "FlattenColumnsBlock",
+                "required": ["value_name", "var_cols", "var_name"],
+                "additionalProperties": false,
+                "properties": {
+                  "value_name": {
+                    "type": "string"
+                  },
+                  "var_cols": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "var_name": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "description": "DuplicateColumnsBlock",
+                "required": ["columns_map"],
+                "additionalProperties": false,
+                "properties": {
+                  "columns_map": {
+                    "type": "object"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "description": "RenameColumnsBlock",
+                "required": ["columns_map"],
+                "additionalProperties": false,
+                "properties": {
+                  "columns_map": {
+                    "type": "object"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "description": "SetToMajorityValueBlock",
+                "required": ["col_name"],
+                "additionalProperties": false,
+                "properties": {
+                  "col_name": {
+                    "type": "string"
+                  }
+                }
               }
             ]
           }


### PR DESCRIPTION
Update the v1 pipeline schema to include the blocks added by #182

Refs #205

Add a new schema entry for eachof these blocks.

Note that the entry for DuplicateColumnsBlock and RenameColumnsBlock is identical - so could have been combined - 
 but it will be easier to audit the correctness of the schema vs the code	if we have both entries.
