### PR TITLE
Add data checkpointing capability

### DIFF
--- a/src/instructlab/sdg/checkpointing.py
+++ b/src/instructlab/sdg/checkpointing.py
@@ -80,8 +80,7 @@ class Checkpointer:
         generated_df = generated_data_common.to_pandas()
 
         # Identify missing rows
-        missing_df = seed_df[
-            ~seed_df.apply(tuple, 1).isin(generated_df.apply(tuple, 1))
-        ]
+        missing_rows = ~seed_df.apply(tuple, 1).isin(generated_df.apply(tuple, 1))
 
+        missing_df = seed_data.to_pandas()[missing_rows]
         return pandas.dataset_from_pandas_dataframe(missing_df)

--- a/src/instructlab/sdg/checkpointing.py
+++ b/src/instructlab/sdg/checkpointing.py
@@ -1,0 +1,87 @@
+# Standard
+import logging
+import uuid
+
+# Third Party
+from datasets import Dataset, concatenate_datasets, load_dataset
+from datasets.data_files import EmptyDatasetError
+
+# First Party
+from instructlab.sdg.utils import pandas
+
+logger = logging.getLogger(__name__)
+
+
+class Checkpointer:
+    def __init__(self, checkpoint_dir=None, save_freq=1):
+        self._checkpoint_dir = checkpoint_dir
+
+        self._save_freq = save_freq
+        self._cache = []
+
+    def checkpoint(self, dataset):
+        self._cache.append(dataset)
+        if len(self._cache) < self._save_freq:
+            return
+        self.save()
+        self._cache.clear()
+
+    def done(self):
+        if self._cache:
+            self.save()
+            self._cache.clear()
+
+    def save(self):
+        if self._checkpoint_dir is None:
+            return
+        checkpoint_id = uuid.uuid4().hex
+        checkpoint_file = (
+            f"{self._checkpoint_dir}/data_checkpoint_{checkpoint_id}.jsonl"
+        )
+        logger.info(f"Saving checkpoint to {checkpoint_file}")
+        # Saves all the current records to new file in the checkpoint dir
+        concatenate_datasets(self._cache).to_json(
+            checkpoint_file, orient="records", lines=True
+        )
+
+    def load(self, dataset: Dataset) -> Dataset:
+        if self._checkpoint_dir is None:
+            return dataset, None
+
+        try:
+            pre_generated_data = load_dataset(
+                "json", data_dir=self._checkpoint_dir, split="train"
+            )
+        except EmptyDatasetError:
+            logger.info(
+                f"No existing checkpoints found in {self._checkpoint_dir}, generating from scratch"
+            )
+            return dataset, None
+
+        logger.info(
+            f"Loading existing checkpoints from {self._checkpoint_dir}, with {pre_generated_data.num_rows} rows"
+        )
+        seed_data = self._get_missing_data(dataset, pre_generated_data)
+        logger.info(f"Found {seed_data.num_rows} missing rows in the dataset")
+        return seed_data, pre_generated_data
+
+    def _get_missing_data(self, seed_data, generated_data):
+        # Get the common columns between the two datasets
+        common_columns = list(
+            set(seed_data.column_names) & set(generated_data.column_names)
+        )
+
+        # Extract the relevant data based on common columns
+        seed_data_common = seed_data.select_columns(common_columns)
+        generated_data_common = generated_data.select_columns(common_columns)
+
+        # Convert to Pandas DataFrames for easier comparison
+        seed_df = seed_data_common.to_pandas()
+        generated_df = generated_data_common.to_pandas()
+
+        # Identify missing rows
+        missing_df = seed_df[
+            ~seed_df.apply(tuple, 1).isin(generated_df.apply(tuple, 1))
+        ]
+
+        return pandas.dataset_from_pandas_dataframe(missing_df)

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -1,0 +1,102 @@
+# Standard
+import json
+import os
+
+# Third Party
+from datasets import Dataset
+import pytest
+
+# First Party
+from instructlab.sdg.checkpointing import Checkpointer
+
+
+def _add_bar(sample, add_value=100):
+    sample["bar"] = sample["foo"] + add_value
+    return sample
+
+
+def _populate_checkpoints(tmpdir, dataset, checkpoints_count):
+    for i in range(0, checkpoints_count):
+        checkpoint_dataset = dataset.select(range(i * 10, (i + 1) * 10))
+        checkpoint_dataset = checkpoint_dataset.map(
+            lambda x: _add_bar(x, add_value=100)
+        )
+        checkpoint_dataset.to_json(
+            os.path.join(tmpdir, f"data_checkpoint_abcde{i}.jsonl"),
+            orient="records",
+            lines=True,
+        )
+
+
+def _validate_checkpoints(tmpdir, expected_files_count, expected_length):
+    saved_files = os.listdir(tmpdir)
+    assert len(saved_files) == expected_files_count
+    assert all(f.startswith("data_checkpoint_") for f in saved_files)
+    assert all(f.endswith(".jsonl") for f in saved_files)
+
+    for f in saved_files:
+        with open(os.path.join(tmpdir, f), "r") as f:
+            l = list(f)
+            if isinstance(expected_length, list):
+                expected_length.remove(len(l))
+            else:
+                assert len(l) == expected_length
+            for s in l:
+                data = json.loads(s)
+                assert "foo" in data and "bar" in data
+
+
+@pytest.mark.parametrize(
+    "save_freq, dataset_size, init_checkpoints, splits, final_checkpoints, checkpoint_length",
+    [
+        (1, 10, 0, 0, 1, 10),
+        (1, 100, 1, 9, 10, 10),
+        (1, 100, 2, 8, 10, 10),
+        (3, 100, 2, 8, 5, [10, 10, 30, 30, 20]),
+    ],
+)
+def test_checkpointing(
+    tmpdir,
+    save_freq,
+    dataset_size,
+    init_checkpoints,
+    splits,
+    final_checkpoints,
+    checkpoint_length,
+):
+    # Our initial dataset
+    dataset = Dataset.from_list([{"foo": i} for i in range(dataset_size)])
+
+    # Generate and save some checkpoints to disk
+    _populate_checkpoints(tmpdir, dataset, init_checkpoints)
+
+    # Load checkpoints, giving us the remaining dataset to process and
+    # the generated data loaded from the checkpoints
+    checkpointer = Checkpointer(checkpoint_dir=tmpdir, save_freq=save_freq)
+    dataset, pre_generated_data = checkpointer.load(dataset)
+
+    # When testing save_freq, we will have checkpoints of different lengths
+    if isinstance(checkpoint_length, list):
+        checkpoints_total = sum(checkpoint_length[:init_checkpoints])
+    else:
+        checkpoints_total = checkpoint_length * init_checkpoints
+
+    # Validate pre-generated data loaded from the checkpoints
+    assert len(dataset) == (dataset_size - checkpoints_total)
+    if init_checkpoints > 0:
+        assert len(pre_generated_data) == checkpoints_total
+
+    # Apply pipeline to the remaining dataset and save checkpoints
+    if splits:
+        for i in range(0, splits):
+            split = dataset.select(range(i * 10, (i + 1) * 10))
+            split = split.map(lambda x: _add_bar(x, add_value=100))
+            checkpointer.checkpoint(split)
+    else:
+        dataset = dataset.map(lambda x: _add_bar(x, add_value=10))
+        checkpointer.checkpoint(dataset)
+
+    checkpointer.done()
+
+    # Validate that all checkpoints are now saved to disk
+    _validate_checkpoints(tmpdir, final_checkpoints, checkpoint_length)

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -15,12 +15,14 @@ def _add_bar(sample, add_value=100):
     return sample
 
 
-def _populate_checkpoints(tmpdir, dataset, checkpoints_count):
+def _populate_checkpoints(tmpdir, dataset, checkpoints_count, remove_column):
     for i in range(0, checkpoints_count):
         checkpoint_dataset = dataset.select(range(i * 10, (i + 1) * 10))
         checkpoint_dataset = checkpoint_dataset.map(
             lambda x: _add_bar(x, add_value=100)
         )
+        if remove_column:
+            checkpoint_dataset = checkpoint_dataset.remove_columns("foo")
         checkpoint_dataset.to_json(
             os.path.join(tmpdir, f"data_checkpoint_abcde{i}.jsonl"),
             orient="records",
@@ -28,7 +30,7 @@ def _populate_checkpoints(tmpdir, dataset, checkpoints_count):
         )
 
 
-def _validate_checkpoints(tmpdir, expected_files_count, expected_length):
+def _validate_checkpoints(tmpdir, expected_files_count, expected_length, remove_column):
     saved_files = os.listdir(tmpdir)
     assert len(saved_files) == expected_files_count
     assert all(f.startswith("data_checkpoint_") for f in saved_files)
@@ -43,21 +45,27 @@ def _validate_checkpoints(tmpdir, expected_files_count, expected_length):
                 assert len(l) == expected_length
             for s in l:
                 data = json.loads(s)
-                assert "foo" in data and "bar" in data
+                if remove_column:
+                    assert "foo" not in data and "bar" in data
+                else:
+                    assert "foo" in data and "bar" in data
 
 
 @pytest.mark.parametrize(
-    "save_freq, dataset_size, init_checkpoints, splits, final_checkpoints, checkpoint_length",
+    "save_freq, remove_column, dataset_size, init_checkpoints, splits, final_checkpoints, checkpoint_length",
     [
-        (1, 10, 0, 0, 1, 10),
-        (1, 100, 1, 9, 10, 10),
-        (1, 100, 2, 8, 10, 10),
-        (3, 100, 2, 8, 5, [10, 10, 30, 30, 20]),
+        (1, False, 10, 0, 0, 1, 10),
+        (1, True, 10, 0, 0, 1, 10),
+        (1, False, 100, 1, 9, 10, 10),
+        (1, True, 100, 1, 9, 10, 10),
+        (1, False, 100, 2, 8, 10, 10),
+        (3, False, 100, 2, 8, 5, [10, 10, 30, 30, 20]),
     ],
 )
 def test_checkpointing(
     tmpdir,
     save_freq,
+    remove_column,
     dataset_size,
     init_checkpoints,
     splits,
@@ -65,15 +73,18 @@ def test_checkpointing(
     checkpoint_length,
 ):
     # Our initial dataset
-    dataset = Dataset.from_list([{"foo": i} for i in range(dataset_size)])
+    dataset = Dataset.from_list([{"idx": i, "foo": i} for i in range(dataset_size)])
 
     # Generate and save some checkpoints to disk
-    _populate_checkpoints(tmpdir, dataset, init_checkpoints)
+    _populate_checkpoints(tmpdir, dataset, init_checkpoints, remove_column)
 
     # Load checkpoints, giving us the remaining dataset to process and
     # the generated data loaded from the checkpoints
     checkpointer = Checkpointer(checkpoint_dir=tmpdir, save_freq=save_freq)
     dataset, pre_generated_data = checkpointer.load(dataset)
+
+    # Should be present, even if removed from the checkpoint (remove_column=True)
+    assert "foo" in dataset.features
 
     # When testing save_freq, we will have checkpoints of different lengths
     if isinstance(checkpoint_length, list):
@@ -91,12 +102,16 @@ def test_checkpointing(
         for i in range(0, splits):
             split = dataset.select(range(i * 10, (i + 1) * 10))
             split = split.map(lambda x: _add_bar(x, add_value=100))
+            if remove_column:
+                split = split.remove_columns("foo")
             checkpointer.checkpoint(split)
     else:
         dataset = dataset.map(lambda x: _add_bar(x, add_value=10))
+        if remove_column:
+            dataset = dataset.remove_columns("foo")
         checkpointer.checkpoint(dataset)
 
     checkpointer.done()
 
     # Validate that all checkpoints are now saved to disk
-    _validate_checkpoints(tmpdir, final_checkpoints, checkpoint_length)
+    _validate_checkpoints(tmpdir, final_checkpoints, checkpoint_length, remove_column)

--- a/tests/test_generate_data.py
+++ b/tests/test_generate_data.py
@@ -19,6 +19,8 @@ def test_context_init_batch_size_optional():
         "mixtral",
         "foo.bar",
         1,
+        "/checkpoint/dir",
+        1,
         batch_size=None,
         batch_num_workers=None,
     )
@@ -31,6 +33,8 @@ def test_context_init_batch_size_optional():
         None,
         "mixtral",
         "foo.bar",
+        1,
+        "/checkpoint/dir",
         1,
         batch_size=20,
         batch_num_workers=32,


### PR DESCRIPTION
Fixes https://github.com/instructlab/sdg/issues/195

Needs the following CLI changes to enable it:

- `--batch-size` -- https://github.com/instructlab/instructlab/pull/1889
- `--checkpoint-dir` -- https://github.com/instructlab/instructlab/pull/1797

---


c1c70a5 Add data checkpointing capability

```    
    Introduce a comprehensive data checkpointing mechanism that saves
    intermediate states during data generation. This allows for more
    granular progress tracking and recovery.
    
    Checkpoints are saved periodically based on the save_freq setting,
    preventing data loss and enabling resumption from the last saved state
    in case of interruptions.
    
    The system can resume from a saved checkpoint by comparing the
    generated data with the seed data to identify and process missing
    data.
    
    Each checkpoint is uniquely identified using UUIDs, ensuring distinct
    and traceable save points.
    
    Co-authored-by: shiv <shivchander.s30@gmail.com>
    Co-authored-by: Derek Higgins <derekh@redhat.com>
    Co-authored-by: Mark McLoughlin <markmc@redhat.com>
```


63b3599 checkpointing: fix "missing data" check with removed columns
    
```
    Fix the logic error that means if a pipeline removes a column
    that was present in the original dataset, then checkpointing
    causes the column not be present before the pipeline starts.
    
    Add a test case to the unit test to cover this, but note I
    had to add an additional column to ensure there is at least
    one column in common between the original dataset and the
    checkpoint dataset.
```
