### PR TITLE
Separate checkpoints by leaf nodes

### DIFF
--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -398,7 +398,7 @@ def generate_data(
         logger.debug("Samples: %s", samples)
         ds = Dataset.from_list(samples)
         logger.debug("Dataset: %s", ds)
-        new_generated_data = pipe.generate(ds)
+        new_generated_data = pipe.generate(ds, leaf_node_path)
         if len(new_generated_data) == 0:
             raise EmptyDatasetError(
                 "Pipeline stopped: Empty dataset after running pipe"


### PR DESCRIPTION
The checkpoints need to be saved and loaded per leaf node.  This logic adds leaf node into the checkpoint save path.  Ex:

ls ~/.local/share/instructlab/datasets/checkpoints/knowledge_tonsils_overview_e2e-tonsils/ data_checkpoint_3c0182d541c042f6bacb4e157d1eed5c.jsonl  data_checkpoint_3dd6fc2d53544353b76070a0fe00e277.jsonl  data_checkpoint_7555281c378744c79013541e42f18e42.jsonl