### PR TITLE
Don't write empty checkpoint datasets

### DIFF
--- a/src/instructlab/sdg/checkpointing.py
+++ b/src/instructlab/sdg/checkpointing.py
@@ -22,7 +22,8 @@ class Checkpointer:
         self._cache = []
 
     def checkpoint(self, dataset):
-        self._cache.append(dataset)
+        if len(dataset) != 0:
+            self._cache.append(dataset)
         if len(self._cache) < self._save_freq:
             return
         self.save()

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+from unittest.mock import patch
 import json
 import os
 
@@ -117,3 +118,21 @@ def test_checkpointing(
 
     # Validate that all checkpoints are now saved to disk
     _validate_checkpoints(tmpdir, final_checkpoints, checkpoint_length, remove_column)
+
+
+@patch.object(Checkpointer, "save")
+def test_checkpoint_empty_dataset_doesnt_save_empty_files(mock_save):
+    checkpointer = Checkpointer()
+    empty_dataset = Dataset.from_list([])
+    checkpointer.checkpoint(empty_dataset)
+    checkpointer.done()
+    mock_save.assert_not_called()
+
+
+@patch.object(Checkpointer, "save")
+def test_checkpoint_nonempty_dataset_saves_files(mock_save):
+    checkpointer = Checkpointer()
+    dataset = Dataset.from_list([{"idx": 1, "foo": "bar"}])
+    checkpointer.checkpoint(dataset)
+    checkpointer.done()
+    mock_save.assert_called()


### PR DESCRIPTION
If we end up with empty generated datasets (perhaps because a small teacher model was used and it was unable to generate any samples in our expected format), we don't want to write those empty datasets out as checkpoint files since there is no data in them to checkpoint. This prevents us from having to write special logic on the loading side to deal with loading empty checkpoint files.

Fixes #238