### PR TITLE
Add taxonomy_base='null' option to support using the full taxonomy repo contents

### DIFF
--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -52,6 +52,16 @@ class TestTaxonomy:
         "taxonomy_base, create_tracked_file, create_untracked_file, check_leaf_node_keys",
         [
             ("main", True, True, ["compositional_skills->new"]),
+            ("main", False, True, ["compositional_skills->new"]),
+            ("main", True, False, []),
+            ("main", False, False, []),
+            ("main^", True, False, ["compositional_skills->tracked"]),
+            (
+                "main^",
+                True,
+                True,
+                ["compositional_skills->new", "compositional_skills->tracked"],
+            ),
         ],
     )
     def test_read_taxonomy_leaf_nodes(

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -62,6 +62,13 @@ class TestTaxonomy:
                 True,
                 ["compositional_skills->new", "compositional_skills->tracked"],
             ),
+            ("empty", True, False, ["compositional_skills->tracked"]),
+            (
+                "empty",
+                True,
+                True,
+                ["compositional_skills->new", "compositional_skills->tracked"],
+            ),
         ],
     )
     def test_read_taxonomy_leaf_nodes(


### PR DESCRIPTION
Add a new `null` symbolic value `taxonomy_base`, to allow users to request using the entire taxonomy contents as input to the data generation pipeline.

The reason for this change is the to enable an end to end flow from generate -> train -> evaluate with a complete taxonomy repo.  With the rest of the pipeline as written, using the full taxonomy repo is how a user would start with a base model and be able to add a full taxonomy on top.  You can also think about this in terms of maturity along a git pipeline.  A full pipeline run you would expect to be run further down an integration chain where the taxonomy had already been committed, pushed, and reviewed.

Note: If we do later want to enable a taxonomy diff scenario for the full pipeline, we would need to handle the data mixing from previous layers of the taxonomy as part of the pipeline.

We expect users will use this option in conjunction with the `full` pipeline. For the `simple` pipeline, the use case is more about making quick changes to the taxonomy and getting a relatively quick turnaround on understanding if the change made a difference.  Which is why the diff approach makes sense there.

A full user flow might something look like:
- Make change to the taxonomy on local hardware
- ilab taxonomy diff
- ilab data generate --pipeline simple
- ilab model train
- ilab model chat # to check out the results
- commit taxonomy changes and push
- pull taxonomy onto heavier duty hardware
- ilab data generate --pipeline full --taxonomy-base null
- ilab model train
- ilab model evaluate
