### PR TITLE
WIP: Support taxonomy_base=null as a way to specify that the entire contents of a taxonomy repo should be used

### DIFF
--- a/src/instructlab/sdg/utils/taxonomy.py
+++ b/src/instructlab/sdg/utils/taxonomy.py
@@ -60,6 +60,16 @@ def _get_taxonomy_diff(repo="taxonomy", base="origin/main"):
         re_git_branch = re.compile(f"remotes/{base}$", re.MULTILINE)
     elif base in branches:
         re_git_branch = re.compile(f"{base}$", re.MULTILINE)
+    elif base == "null":
+        # NOTE: this is the tree ID for an empty tree as produced by:
+        #
+        #   `git hash-object -t tree /dev/null`
+        #
+        # This is a "well known" hash and will work with any repo unless
+        # git's hashing algorithm changes.
+        #
+        # FIXME: generate this hash at runtime for safety
+        base_object = repo.tree('4b825dc642cb6eb9a060e54bf8d69288fbee4904')
     else:
         try:
             base_object = repo.commit(base)

--- a/src/instructlab/sdg/utils/taxonomy.py
+++ b/src/instructlab/sdg/utils/taxonomy.py
@@ -73,7 +73,7 @@ def _get_taxonomy_diff(repo="taxonomy", base="origin/main"):
     # Move backwards from HEAD until we find the first commit that is part of base
     # then we can take our diff from there
     current_commit = repo.commit("HEAD")
-    while not base_object:
+    while base_object is None:
         branches = repo.git.branch("-a", "--contains", current_commit.hexsha)
         if re_git_branch.findall(branches):
             base_object = current_commit


### PR DESCRIPTION
This allows users to specify that they want all taxonomy files in their repo to be included, where 'null' symbolically represents the empty tree before this repo was created.

See #242 for more background.

TODO:

- [ ] Add a unit test
- [ ] Propose an `instructlab/instructlab` PR to make `ilab taxonomy diff` support this also
- [ ] Add documentation