### PR TITLE
remove instructlab from requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,6 @@
 
 -r requirements.txt
 
-# TODO: remove 'instructlab' once https://github.com/instructlab/sdg/issues/6 is resolved
-instructlab>=0.17.0
 pre-commit>=3.0.4,<4.0
 pylint>=2.16.2,<4.0
 pylint-pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 click>=8.1.7,<9.0.0
+datasets>=2.18.0,<3.0.0
+GitPython>=3.1.42,<4.0.0
 httpx>=0.25.0,<1.0.0
 langchain-text-splitters
 openai>=1.13.3,<2.0.0


### PR DESCRIPTION
It is not required anymore because https://github.com/instructlab/sdg/issues/6 is resolved.

Add required requirements instead of `instructlab`.

