### PR TITLE
tests: Remove custom yaml rules

### DIFF
--- a/tests/test_generate_data.py
+++ b/tests/test_generate_data.py
@@ -25,12 +25,6 @@ from instructlab.sdg.pipeline import PipelineContext
 
 TEST_TAXONOMY_BASE = "main"
 
-TEST_CUSTOM_YAML_RULES = """extends: relaxed
-rules:
-  line-length:
-    max: 180
-"""
-
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "testdata")
 
 NUM_INSTRUCTIONS_TO_GENERATE = 10
@@ -317,7 +311,6 @@ class TestGenerateCompositionalData(unittest.TestCase):
                 taxonomy=self.test_taxonomy.root,
                 taxonomy_base=TEST_TAXONOMY_BASE,
                 output_dir=self.tmp_path,
-                yaml_rules=TEST_CUSTOM_YAML_RULES,
                 pipeline="simple",
             )
 
@@ -394,7 +387,6 @@ class TestGenerateKnowledgeData(unittest.TestCase):
                 taxonomy=self.test_taxonomy.root,
                 taxonomy_base=TEST_TAXONOMY_BASE,
                 output_dir=self.tmp_path,
-                yaml_rules=TEST_CUSTOM_YAML_RULES,
                 chunk_word_count=1000,
                 server_ctx_size=4096,
                 pipeline="simple",

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -14,13 +14,6 @@ from instructlab.sdg.utils import taxonomy
 
 TEST_SEED_EXAMPLE = "Can you help me debug this failing unit test?"
 
-TEST_CUSTOM_YAML_RULES = """extends: relaxed
-
-rules:
-  line-length:
-    max: 180
-"""
-
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "testdata")
 
 
@@ -65,7 +58,6 @@ class TestTaxonomy:
         create_tracked_file,
         create_untracked_file,
         check_leaf_node_keys,
-        tmp_path,
     ):
         tracked_file = "compositional_skills/tracked/qna.yaml"
         untracked_file = "compositional_skills/new/qna.yaml"
@@ -78,10 +70,8 @@ class TestTaxonomy:
         if create_untracked_file:
             self.taxonomy.create_untracked(untracked_file, test_compositional_skill)
 
-        custom_config_yaml = tmp_path.joinpath("custom_config.yaml")
-        custom_config_yaml.write_text(TEST_CUSTOM_YAML_RULES, encoding="utf-8")
         leaf_nodes = taxonomy.read_taxonomy_leaf_nodes(
-            self.taxonomy.root, taxonomy_base, str(custom_config_yaml)
+            self.taxonomy.root, taxonomy_base, None
         )
         assert len(leaf_nodes) == len(check_leaf_node_keys)
 


### PR DESCRIPTION
schema v0.4.1 no longer lints line length. So we don't need custom yaml rules in the test to enable 180 line length.

Also the use in test_generate_data was incorrect since the argument must be the path to a file containing the yaml config rather than the config itself.