### PR TITLE
ci: add AWS tag to show github PR number for all jobs

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x4.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x4.yml
@@ -38,7 +38,8 @@ jobs:
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "instructlab-ci-github-large-runner"},
-              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
+              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
+              {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
             ]
 
   e2e:

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -48,7 +48,8 @@ jobs:
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "instructlab-ci-github-small-runner"},
-              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
+              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
+              {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
             ]
 
   e2e:


### PR DESCRIPTION
right now we can see what type of runner and which repository an AWS runner is associated with, but not which PR number triggered it

see https://github.com/instructlab/instructlab/pull/2183 for reference