### PR TITLE
ci: add GitHubRef to AWS labels as well

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x4.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x4.yml
@@ -39,6 +39,7 @@ jobs:
             [
               {"Key": "Name", "Value": "instructlab-ci-github-large-runner"},
               {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
+              {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
               {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
             ]
 

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -49,6 +49,7 @@ jobs:
             [
               {"Key": "Name", "Value": "instructlab-ci-github-small-runner"},
               {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
+              {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
               {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
             ]
 


### PR DESCRIPTION
including this in addition to the previously added PR number has that value is blank for runs against the main branch