### PR TITLE
Mistral Family support and Logging

### DIFF
--- a/src/instructlab/sdg/utils/models.py
+++ b/src/instructlab/sdg/utils/models.py
@@ -14,9 +14,7 @@ DEFAULT_MODEL_FAMILY = "merlinite"
 MODEL_FAMILIES = set(("merlinite", "mixtral"))
 
 # Map model names to their family
-MODEL_FAMILY_MAPPINGS = {
-    "granite": "merlinite",
-}
+MODEL_FAMILY_MAPPINGS = {"granite": "merlinite", "mistral": "mixtral"}
 
 
 def get_model_family(model_family, model_path):


### PR DESCRIPTION
Add support for mistral models. They use the same prompt template as Mixtral. This dramatically increases the performance of the full pipeline on a laptop using LLamaCPP. The issue with Mixtral is that even in GGUF form the model is too big for most consumer hardware. Completions and prompting using this model hang for long periods of time.

The logging I added is optional debug logs that print all of the prompts in each LLMBlock and the prompt currently being generated.

I also added a loading bar for each LLMBlock pass that increments each time we get a prompt response back.