### PR TITLE
Update Python 3.12

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x4.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x4.yml
@@ -114,27 +114,27 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git python3.12 python3.12-devel
 
       - name: Install ilab
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="/home/ec2-user/.local/bin:/usr/local/cuda/bin:$PATH"
-          python3.11 -m venv --upgrade-deps venv
+          python3.12 -m venv --upgrade-deps venv
           . venv/bin/activate
           git clone https://github.com/instructlab/instructlab
           cd instructlab
           sed 's/\[.*\]//' requirements.txt > constraints.txt
-          python3.11 -m pip cache remove llama_cpp_python
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-binary llama_cpp_python -c constraints.txt llama_cpp_python
-          python3.11 -m pip install bitsandbytes
-          python3.11 -m pip install .
+          python3.12 -m pip cache remove llama_cpp_python
+          CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.12 -m pip install --force-reinstall --no-binary llama_cpp_python -c constraints.txt llama_cpp_python
+          python3.12 -m pip install bitsandbytes
+          python3.12 -m pip install .
 
       - name: Install sdg
         run: |
           . venv/bin/activate
-          python3.11 -m pip install .
+          python3.12 -m pip install .
 
       - name: Run e2e test
         env:

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -115,23 +115,23 @@ jobs:
       - name: Install system packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git python3.12 python3.12-devel
 
       - name: Install instructlab
         working-directory: ./instructlab
         run: |
           export PATH="/home/ec2-user/.local/bin:/usr/local/cuda/bin:$PATH"
-          python3.11 -m venv --upgrade-deps venv
+          python3.12 -m venv --upgrade-deps venv
           . venv/bin/activate
           nvidia-smi
-          python3.11 -m pip cache remove llama_cpp_python
+          python3.12 -m pip cache remove llama_cpp_python
 
-          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install .
+          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.12 -m pip install .
 
           # https://github.com/instructlab/instructlab/issues/1821
           # install with Torch and build dependencies installed
-          python3.11 -m pip install packaging wheel setuptools-scm
-          python3.11 -m pip install .[cuda]
+          python3.12 -m pip install packaging wheel setuptools-scm
+          python3.12 -m pip install .[cuda]
         
       - name: Update instructlab-sdg library
         working-directory: ./sdg

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,10 +73,10 @@ jobs:
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0  
 
-      - name: Setup Python 3.11
+      - name: Setup Python 3.12
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
-          python-version: 3.11
+          python-version: 3.12
           cache: pip
           cache-dependency-path: |
             **/pyproject.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,10 +44,13 @@ jobs:
         python:
           - "3.10"
           - "3.11"
+          - "3.12"
         platform:
           - "ubuntu-latest"
         include:
           - python: "3.11"
+            platform: "macos-latest"
+          - python: "3.12"
             platform: "macos-latest"
     steps:
       - name: "Harden Runner"

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 [tox]
 # py3-unit runs unit tests with 'python3'
-# py311-unit runs the same tests with 'python3.11'
+# py312-unit runs the same tests with 'python3.12'
 envlist = ruff, lint, mypy, spellcheck, py3-unit
 minversion = 4.4
 
@@ -82,5 +82,6 @@ commands =
 
 [gh]
 python =
+    3.12 = py312-unitcov
     3.11 = py311-unitcov
     3.10 = py310-unitcov


### PR DESCRIPTION
Now that PyTorch 2.4 supports Python 3.12, This change attempts updating the default Python version to 3.12, jointly with the other repositories of the instructlab project.