### PR TITLE
fix: medium E2E CI job was missing HF_TOKEN

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x1.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x1.yml
@@ -136,6 +136,8 @@ jobs:
   
       - name: Run e2e test
         working-directory: ./instructlab
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           . venv/bin/activate
           ./scripts/e2e-ci.sh -m


### PR DESCRIPTION
Followup on https://github.com/instructlab/sdg/pull/318