### PR TITLE
ci: use org variable for AWS EC2 AMI in E2E CI jobs

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x1.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x1.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-01a89eee1adde309c
+          ec2-image-id: ${{ vars.AWS_EC2_AMI }}
           ec2-instance-type: g5.4xlarge
           subnet-id: subnet-02d230cffd9385bd4
           security-group-id: sg-06300447c4a5fbef3

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-01a89eee1adde309c
+          ec2-image-id: ${{ vars.AWS_EC2_AMI }}
           ec2-instance-type: g4dn.2xlarge
           subnet-id: subnet-02d230cffd9385bd4
           security-group-id: sg-06300447c4a5fbef3


### PR DESCRIPTION
This will allow us to do the following:
1. Keep the AMI consistent across all of InstructLab
2. Allow for updating the AMI without having to make a code change