### PR TITLE
ci: convert med E2E CI job to L4 GPU

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -30,21 +30,23 @@ pull_request_rules:
     # e2e medium workflow
     - or:
       - and:
+        # note this should match the triggering criteria in 'e2e-nvidia-l4-x1.yml'
         - check-success~=e2e-medium-workflow-complete
         - or:
           - files~=\.py$
           - files=pyproject.toml
           - files=^requirements.*\.txt$
-          - files=.github/workflows/e2e-nvidia-a10g-x1.yml
+          - files=.github/workflows/e2e-nvidia-l4-x1.yml
       - and:
         - -files~=\.py$
         - -files=pyproject.toml
         - -files~=^requirements.*\.txt$
-        - -files=.github/workflows/e2e-nvidia-a10g-x1.yml
+        - -files=.github/workflows/e2e-nvidia-l4-x1.yml
 
     # e2e small workflow
     - or:
       - and:
+        # note this should match the triggering criteria in 'e2e-nvidia-t4-x1.yml'
         - check-success~=e2e-small-workflow-complete
         - or:
           - files~=\.py$

--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-name: E2E (NVIDIA A10G x1)
+name: E2E (NVIDIA L4 x1)
 
 on:
   # run against every merge commit to 'main' and release branches
@@ -18,7 +18,7 @@ on:
       - '**.py'
       - 'pyproject.toml'
       - 'requirements**.txt'
-      - '.github/workflows/e2e-nvidia-a10g-x1.yml' # This workflow
+      - '.github/workflows/e2e-nvidia-l4-x1.yml' # This workflow
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
@@ -55,7 +55,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ${{ vars.AWS_EC2_AMI }}
-          ec2-instance-type: g5.4xlarge
+          ec2-instance-type: g6.8xlarge
           subnet-id: subnet-02d230cffd9385bd4
           security-group-id: sg-06300447c4a5fbef3
           iam-role-name: instructlab-ci-runner
@@ -117,18 +117,18 @@ jobs:
           nvidia-smi
           python3.11 -m pip cache remove llama_cpp_python
 
-          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install .
+          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install  -v .
 
           # https://github.com/instructlab/instructlab/issues/1821
           # install with Torch and build dependencies installed
-          python3.11 -m pip install packaging wheel setuptools-scm
-          python3.11 -m pip install .[cuda] -r requirements-vllm-cuda.txt
+          python3.11 -m pip install  -v packaging wheel setuptools-scm
+          python3.11 -m pip install  -v .[cuda] -r requirements-vllm-cuda.txt
   
       - name: Update instructlab-sdg library
         working-directory: ./sdg
         run: |
           . ../instructlab/venv/bin/activate
-          pip install .
+          pip install  -v .
 
       - name: Check disk
         run: |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@
 ![License](https://img.shields.io/github/license/instructlab/sdg)
 
 ![`e2e-nvidia-t4-x1.yaml` on `main`](https://github.com/instructlab/sdg/actions/workflows/e2e-nvidia-t4-x1.yml/badge.svg?branch=main)
-![`e2e-nvidia-a10g-x1.yaml` on `main`](https://github.com/instructlab/sdg/actions/workflows/e2e-nvidia-a10g-x1.yml/badge.svg?branch=main)
+![`e2e-nvidia-l4-x1.yaml` on `main`](https://github.com/instructlab/sdg/actions/workflows/e2e-nvidia-l4-x1.yml/badge.svg?branch=main)
 
 Python library for Synthetic Data Generation


### PR DESCRIPTION
also adds '-v' to 'pip install' so we can see environmental variable info for debugging issues related to installation

Addn Context: The A10G runner was not working with the new version of VLLM we will be using - this will ensure the continuing functionality of the Medium job in this repo