### PR TITLE
feat: support converting messages datasets into multiple pre-training formats

### DIFF
--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -269,6 +269,7 @@ def generate_data(
     client: openai.OpenAI,
     logger: logging.Logger = logger,  # pylint: disable=redefined-outer-name
     system_prompt: Optional[str] = None,
+    use_legacy_pretraining_format: Optional[bool] = True,
     model_family: Optional[str] = None,
     model_name: Optional[str] = None,
     num_cpus: Optional[int] = None,
@@ -423,7 +424,12 @@ def generate_data(
                 date_suffix,
             )
 
-        mixer.collect(leaf_node_path, new_generated_data, is_knowledge)
+        mixer.collect(
+            leaf_node_path,
+            new_generated_data,
+            is_knowledge,
+            use_legacy_pretraining_format,
+        )
 
     if generated_data is None:
         generated_data = []


### PR DESCRIPTION
This PR adds support for  converting messages datasets into multiple pre-training formats to support working with both granite 7b and granite 3.0 student models. It accepts a `use_legacy_pretraining_format` parameter as input to appropriately choose the right format to use

This is intended to be a short term solution, with the long term idea being that SDG would be agnostic of student model requirements such as these 