### PR TITLE
Move to Docling v2 APIs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 click>=8.1.7,<9.0.0
 datasets>=2.18.0,<3.0.0
-docling>=1.15.0,<2.0.0
+docling>=2.3.0,<3.0.0
 GitPython>=3.1.42,<4.0.0
 httpx>=0.25.0,<1.0.0
 instructlab-schema>=0.4.0

--- a/src/instructlab/sdg/utils/taxonomy.py
+++ b/src/instructlab/sdg/utils/taxonomy.py
@@ -10,7 +10,9 @@ import re
 
 # Third Party
 from datasets import Dataset
-from docling_parse.docling_parse import pdf_parser  # pylint: disable=no-name-in-module
+
+# pylint: disable=no-name-in-module
+from docling_parse.docling_parse import pdf_parser_v1
 from instructlab.schema.taxonomy import DEFAULT_TAXONOMY_FOLDERS as TAXONOMY_FOLDERS
 from instructlab.schema.taxonomy import (
     TaxonomyMessageFormat,
@@ -25,7 +27,7 @@ import yaml
 from .chunkers import DocumentChunker
 
 # Initialize the pdf parser
-PDFParser = pdf_parser()
+PDFParser = pdf_parser_v1()
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +167,7 @@ def _get_documents(
                                 )
 
                         elif file_path.lower().endswith(".pdf"):
-                            # Process PDF files using docling_parse's pdf_parser
+                            # Process PDF files using docling_parse's pdf_parser_v1
                             doc_key = f"key_{os.path.basename(file_path)}"  # Unique document key
                             logger.info(f"Loading PDF document from {file_path}")
 

--- a/tests/test_chunkers.py
+++ b/tests/test_chunkers.py
@@ -5,9 +5,6 @@ from pathlib import Path
 import tempfile
 
 # Third Party
-from docling.datamodel.base_models import PipelineOptions
-from docling.datamodel.document import ConvertedDocument, DocumentConversionInput
-from docling.document_converter import ConversionStatus, DocumentConverter
 import pytest
 
 # First Party


### PR DESCRIPTION
This bumps our Docling dependency to version 2, while using the backwards-compatibility layer they have for pdf_parser_v1 and legacy document output formats. Fixes #333 