### PR TITLE
Only use CPU for the docling OCR models

### DIFF
--- a/src/instructlab/sdg/utils/chunkers.py
+++ b/src/instructlab/sdg/utils/chunkers.py
@@ -213,6 +213,8 @@ class ContextAwareChunker(ChunkerBase):  # pylint: disable=too-many-instance-att
 
         model_artifacts_path = StandardPdfPipeline.download_models_hf()
         pipeline_options = PdfPipelineOptions(artifacts_path=model_artifacts_path)
+        # Keep OCR models on the CPU instead of GPU
+        pipeline_options.ocr_options.use_gpu = False
         converter = DocumentConverter(
             format_options={
                 InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)


### PR DESCRIPTION
Because GPU memory is extremely tight in many of our supported hardware configurations, and because our GitHub Mac CI runners error out when running the OCR models with MPS acceleration, let's just explicitly pin the OCR models to the CPU.

See DS4SD/docling#286 for a bit more context.