### PR TITLE
Prefer tesserocr over easyocr, if available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 click>=8.1.7,<9.0.0
 datasets>=2.18.0,<3.0.0
-docling>=2.4.2,<3.0.0
+docling[tesserocr]>=2.4.2,<3.0.0
 GitPython>=3.1.42,<4.0.0
 httpx>=0.25.0,<1.0.0
 instructlab-schema>=0.4.0

--- a/src/instructlab/sdg/utils/chunkers.py
+++ b/src/instructlab/sdg/utils/chunkers.py
@@ -18,17 +18,8 @@ from docling.datamodel.pipeline_options import (
     PdfPipelineOptions,
     TesseractOcrOptions,
 )
-from docling.document_converter import (
-    ConversionStatus,
-    DocumentConverter,
-    PdfFormatOption,
-)
-from docling.models.easyocr_model import EasyOcrModel
-from docling.models.tesseract_ocr_model import TesseractOcrModel
-from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
 from langchain_text_splitters import Language, RecursiveCharacterTextSplitter
 from tabulate import tabulate
-from transformers import AutoTokenizer
 
 logger = logging.getLogger(__name__)
 _DEFAULT_CHUNK_OVERLAP = 100
@@ -46,6 +37,10 @@ def resolve_ocr_options() -> OcrOptions:
     # First, attempt to use tesserocr
     try:
         ocr_options = TesseractOcrOptions()
+        # pylint: disable=import-outside-toplevel
+        # Third Party
+        from docling.models.tesseract_ocr_model import TesseractOcrModel
+
         _ = TesseractOcrModel(True, ocr_options)
         return ocr_options
     except ImportError:
@@ -55,6 +50,11 @@ def resolve_ocr_options() -> OcrOptions:
         ocr_options = EasyOcrOptions()
         # Keep easyocr models on the CPU instead of GPU
         ocr_options.use_gpu = False
+        # triggers torch loading, import lazily
+        # pylint: disable=import-outside-toplevel
+        # Third Party
+        from docling.models.easyocr_model import EasyOcrModel
+
         _ = EasyOcrModel(True, ocr_options)
         return ocr_options
     except ImportError:
@@ -238,6 +238,12 @@ class ContextAwareChunker(ChunkerBase):  # pylint: disable=too-many-instance-att
         Returns:
             List: a list of chunks from the documents
         """
+        # triggers torch loading, import lazily
+        # pylint: disable=import-outside-toplevel
+        # Third Party
+        from docling.document_converter import DocumentConverter, PdfFormatOption
+        from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
+
         if self.document_paths == []:
             return []
 
@@ -344,6 +350,11 @@ class ContextAwareChunker(ChunkerBase):  # pylint: disable=too-many-instance-att
         Returns:
             AutoTokenizer: The tokenizer instance.
         """
+        # import lazily to not load transformers at top level
+        # pylint: disable=import-outside-toplevel
+        # Third Party
+        from transformers import AutoTokenizer
+
         try:
             tokenizer = AutoTokenizer.from_pretrained(model_name)
             logger.info(f"Successfully loaded tokenizer from: {model_name}")
@@ -575,6 +586,11 @@ class ContextAwareChunker(ChunkerBase):  # pylint: disable=too-many-instance-att
         Returns:
             Path: path to directory with docling json artifacts
         """
+        # triggers torch loading, import lazily
+        # pylint: disable=import-outside-toplevel
+        # Third Party
+        from docling.document_converter import ConversionStatus
+
         docling_artifacts_path = self.output_dir / "docling-artifacts"
         docling_artifacts_path.mkdir(parents=True, exist_ok=True)
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,14 @@
+# Standard
+import pathlib
+import typing
+
+# Third Party
+import pytest
+
+TESTS_PATH = pathlib.Path(__file__).parent.parent.absolute()
+
+
+@pytest.fixture
+def testdata_path() -> typing.Generator[pathlib.Path, None, None]:
+    """Path to local test data directory"""
+    yield TESTS_PATH / "testdata"

--- a/tests/functional/test_imports.py
+++ b/tests/functional/test_imports.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+import pathlib
+import subprocess
+import sys
+
+
+def test_sdg_imports(testdata_path: pathlib.Path):
+    script = testdata_path / "leanimports.py"
+    subprocess.check_call([sys.executable, str(script)], text=True)

--- a/tests/test_chunkers.py
+++ b/tests/test_chunkers.py
@@ -100,7 +100,7 @@ def test_resolve_ocr_options_is_not_none():
     assert ocr_options is not None
 
 
-@patch("instructlab.sdg.utils.chunkers.TesseractOcrModel")
+@patch("docling.models.tesseract_ocr_model.TesseractOcrModel")
 def test_resolve_ocr_options_prefers_tessserocr(mock_tesseract):
     """
     Ensure resolve_ocr_options defaults to tesserocr if we're able
@@ -111,7 +111,7 @@ def test_resolve_ocr_options_prefers_tessserocr(mock_tesseract):
     assert isinstance(ocr_options, TesseractOcrOptions)
 
 
-@patch("instructlab.sdg.utils.chunkers.TesseractOcrModel")
+@patch("docling.models.tesseract_ocr_model.TesseractOcrModel")
 def test_resolve_ocr_options_falls_back_to_easyocr(mock_tesseract):
     """
     Ensure resolve_ocr_options falls back to easyocr if we cannot
@@ -122,8 +122,8 @@ def test_resolve_ocr_options_falls_back_to_easyocr(mock_tesseract):
     assert isinstance(ocr_options, EasyOcrOptions)
 
 
-@patch("instructlab.sdg.utils.chunkers.TesseractOcrModel")
-@patch("instructlab.sdg.utils.chunkers.EasyOcrModel")
+@patch("docling.models.tesseract_ocr_model.TesseractOcrModel")
+@patch("docling.models.easyocr_model.EasyOcrModel")
 @patch("logging.Logger.error")
 def test_resolve_ocr_options_none_found_logs_error(
     mock_logger, mock_easyocr, mock_tesseract

--- a/tests/testdata/leanimports.py
+++ b/tests/testdata/leanimports.py
@@ -1,0 +1,15 @@
+"""Helper for test_sdg_imports"""
+
+# Standard
+import sys
+
+# block slow imports
+for unwanted in ["deepspeed", "llama_cpp", "torch", "transformers", "vllm"]:
+    # importlib raises ModuleNotFound when sys.modules value is None.
+    assert unwanted not in sys.modules
+    sys.modules[unwanted] = None  # type: ignore[assignment]
+
+# First Party
+# This will trigger errors if any of the import chain tries to load
+# the unwanted modules
+from instructlab.sdg.generate_data import generate_data


### PR DESCRIPTION
When setting up our ingestion pipeline, explicitly check if tesserocr is available and Docling can load it. If so, prefer that. Otherwise, attempt the same for EasyOCR. If neither can load, log an error and disable optical character recognition.

Fixes #352