### PR TITLE
Prepare release-v0.3 branch for backports

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -74,10 +74,11 @@ pull_request_rules:
   conditions:
     - or:
       - files=.github/mergify.yml
-      - files=.github/workflows/**/*
+      - files~=^\.github/(actions|workflows)/
+      - files=scripts/ruff.sh
+      - files=.pre-commit-config.yaml
       - files=.pylintrc
-      - files=.spellcheck-en-custom.txt
-      - files=.spellcheck.yml
+      - files~=^\.spellcheck[^/]+$
       - files=tox.ini
       - files=.markdownlint-cli2.yaml
   actions:

--- a/.github/workflows/e2e-nvidia-a10g-x4.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x4.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           . venv/bin/activate
           cd instructlab
-          SKIP_TRAIN=1 ./scripts/basic-workflow-tests.sh -mFM
+          SKIP_TRAIN=1 ./scripts/e2e-custom.sh -mFM
 
       - name: Add comment to PR if the workflow failed
         if: failure() && steps.check_pr.outputs.is_pr == 'true'

--- a/.github/workflows/e2e-nvidia-a10g-x4.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x4.yml
@@ -124,6 +124,7 @@ jobs:
           python3.11 -m venv --upgrade-deps venv
           . venv/bin/activate
           git clone https://github.com/instructlab/instructlab
+          git checkout release-v0.19
           cd instructlab
           sed 's/\[.*\]//' requirements.txt > constraints.txt
           python3.11 -m pip cache remove llama_cpp_python

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -145,7 +145,7 @@ jobs:
         working-directory: ./instructlab
         run: |
           . venv/bin/activate
-          ./scripts/basic-workflow-tests.sh -m
+          ./scripts/e2e-custom.sh -msq
 
   stop-runner:
     name: Stop external EC2 runner

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -86,6 +86,7 @@ jobs:
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           repository: "instructlab/instructlab"
+          ref: "release-v0.19"
           path: "instructlab"
           fetch-depth: 0
 


### PR DESCRIPTION
This pins the ilab CLI to an appropriate version for e2e testing and backports some necessary changes to the e2e scripts to get the `release-v0.3` CI usable again.