### PR TITLE
Run the simple pipeline on small runners

### DIFF
--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -145,7 +145,7 @@ jobs:
         working-directory: ./instructlab
         run: |
           . venv/bin/activate
-          ./scripts/e2e-custom.sh -msq
+          ./scripts/e2e-custom.sh -mSsq
 
   stop-runner:
     name: Stop external EC2 runner


### PR DESCRIPTION
Playing whackamole to get a working CI on the 0.3 release branch, I missed
https://github.com/instructlab/instructlab/commit/431d909b83230abcaea25eff74cc9df39894a0c3 where there's a new param to `e2e-custom.sh` that was added and we need to run the simple (vs full) pipeline on the small runner, since it uses a quantized merlinite as the teacher model.