### PR TITLE
Ensure knowledge docs are cloned into unique dirs

### DIFF
--- a/src/instructlab/sdg/utils/taxonomy.py
+++ b/src/instructlab/sdg/utils/taxonomy.py
@@ -2,6 +2,7 @@
 
 # Standard
 from pathlib import Path
+from tempfile import mkdtemp
 from typing import Dict, List, Tuple, Union
 import glob
 import logging
@@ -257,14 +258,20 @@ def _read_taxonomy_file(
     try:
         # get seed instruction data
         tax_path = "->".join(taxonomy.path.parent.parts)
+        leaf_node_path = tax_path.replace("->", "_")
         contents = taxonomy.contents
         task_description = contents.get("task_description", None)
         domain = contents.get("domain")
         documents = contents.get("document")
         document_contents, doc_filepaths = None, None
         if documents:
+            os.makedirs(document_output_dir, exist_ok=True)
+            unique_output_dir = mkdtemp(
+                prefix=f"{leaf_node_path}_", dir=document_output_dir
+            )
             document_contents, doc_filepaths = _get_documents(
-                source=documents, document_output_dir=document_output_dir
+                source=documents,
+                document_output_dir=unique_output_dir,
             )
             logger.debug("Content from git repo fetched")
 


### PR DESCRIPTION
Previously, we were attempting to clone multiple knowledge documents into the same destination directory, leading to failures generating data for any run that contained 2+ knowledge leaf nodes.

Now, we clone docs into a guaranteed unique (via `tempfile.mkdtemp`) subdirectory per knowledge leaf node. Just using a subdirectory per leaf node could still have led to collisions if the user ran data generation twice within one minute, which is why this goes the extra step of using `mkdtemp` for guaranteed uniqueness.

Fixes #404