### PR TITLE
requirements.txt: Remove torch upper bound

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ openai>=1.13.3,<2.0.0
 sentencepiece>=0.2.0
 tabulate>=0.9.0
 tenacity>=8.3.0,!=8.4.0
-torch>=2.3.0,<2.5.0
+torch>=2.3.0
 transformers>=4.41.2
 xdg-base-dirs>=6.0.1


### PR DESCRIPTION
instructlab has removed the upper bound for torch as it was causing problems with testing of new ROCm and Cuda releases.

For example, the two most current AMD ROCm releases require a version of torch greater than or equal to 2.5.1.

Remove the torch upper bound.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>