### PR TITLE
feat: allow configurable skills recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.7.0
+
+### Features
+
+* Ability to configure skills recipe. This is managed through the `skills_recipe_path` option, which specifies the file path to a YAML file. This feature is helpful for adjusting the sample size.
+
 ## v0.6.1
 
 ### Fixes

--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -271,6 +271,7 @@ def _mixer_init(
     date_suffix,
     knowledge_auxiliary_inst,
     system_prompt,
+    skills_recipe_path=None,
 ):
     data_dirs = [os.path.join(xdg_data_home(), "instructlab", "sdg")]
     data_dirs.extend(os.path.join(dir, "instructlab", "sdg") for dir in xdg_data_dirs())
@@ -282,6 +283,7 @@ def _mixer_init(
         system_prompt,
         ctx.dataset_num_procs,
         knowledge_auxiliary_inst,
+        skills_recipe_path,
     )
 
 
@@ -308,6 +310,7 @@ def generate_data(
     batch_size: Optional[int] = None,
     checkpoint_dir: Optional[str] = None,
     max_num_tokens: Optional[int] = DEFAULT_MAX_NUM_TOKENS,
+    skills_recipe_path: Optional[str] = None,
 ) -> None:
     """Generate data for training and testing a model.
 
@@ -322,6 +325,7 @@ def generate_data(
                   or an absolute path to a directory containing the pipeline YAML files.
                   We expect three files to be present in this directory: "knowledge.yaml",
                     "freeform_skills.yaml", and "grounded_skills.yaml".
+        skills_recipe_path: Path to a YAML file containing the skills recipe.
     """
     generate_start = time.time()
 
@@ -390,6 +394,7 @@ def generate_data(
         date_suffix,
         knowledge_pipe.auxiliary_inst,
         system_prompt,
+        skills_recipe_path,
     )
 
     if console_output:


### PR DESCRIPTION
55e85c0 feat: allow configurable skills recipe

commit 55e85c0dde843b782ebc199add6f62f5b44755c1
Author: Sébastien Han <seb@redhat.com>
Date:   Mon Dec 9 10:58:54 2024 +0100

    feat: allow configurable skills recipe
    
    Introduced the ability to specify a custom skills recipe file via the
    `skills_recipe_path` option. This enhancement enables users to
    fine-tune data mixing processes by providing a tailored YAML recipe.
    Practical use cases include adjusting sampling sizes or customizing
    dataset definitions.
    
    Co-authored-by: Michael Clifford <mcliffor@redhat.com>
    Signed-off-by: Sébastien Han <seb@redhat.com>
