### PR TITLE
fix: Restrict `docling` library versions to resolve dependency issues + update `mypy` linting packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 click>=8.1.7,<9.0.0
 datasets>=2.18.0,<3.0.0
-docling[tesserocr]>=2.4.2,<3.0.0
+docling[tesserocr]>=2.4.2,<=2.8.3
+docling-parse>=2.0.0,<3.0.0
 GitPython>=3.1.42,<4.0.0
 gguf>=0.6.0
 httpx>=0.25.0,<1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -73,10 +73,13 @@ allowlist_externals = sh
 
 [testenv:mypy]
 description = Python type checking with mypy
+# Note: 'mypy<1.14' by default pulls the latest 'pydantic' release as a dependency, but 'pydantic>=2.10' does not
+# work with 'mypy<1.14', so for compatibility purposes, we set 'pydantic<=2.9.2'
 deps =
-  mypy>=1.10.0,<2.0
+  mypy>=1.10.0,<1.14
   types-PyYAML
   pytest
+  pydantic<=2.9.2
 commands =
   mypy src
 


### PR DESCRIPTION
`docling-parse` is automatically pulled in by `docling` as a dependency, and v3.0.0 of `docling-parse` contains breaking syntax changes that prevent our e2e builds in `instructlab` from succeeding. See issue in InstructLab here: https://github.com/instructlab/instructlab/issues/2765

For now, we will pin `docling-parse` to the latest v2 release while we investigate how we can update the `docling-parse` syntax to use the new v3 syntax. We will also pin to `docling<=2.8.3` because v2.10.0 was updated to use `docling-parse>=3.0.0`. See here: https://github.com/DS4SD/docling/releases/tag/v2.10.0 (`Docling-parse v2 as default PDF backend`)

Finally, `mypy`  is experiencing issues with a breaking upstream change, too. By default, `mypy` pulls in the latest version of `pydantic`, which is unfortunately now incompatible with `mypy` as of its v2.10 release. See:

  - https://github.com/python/mypy/issues/18191
  - https://github.com/pydantic/pydantic/issues/10950

To workaround this dependency issue, I pinned the related dependency, `pydantic`, to `<=v2.9.2` in our `tox.ini` file. This will force our latest `mypy` to use a compatible `pydantic`. However, note that I did also pin `mypy>=1.0,<1.14`. I did this as a safety measure for when the `mypy` maintainers inevitably fix the issue in v1.14 or later.