### PR TITLE
Document updating of CHANGELOG.md as part of release

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -3,10 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 Backport
 backported
+backporting
+CHANGELOG
 CLI
 codebase
-composable
 Composable
+composable
 config
 configs
 customizable
@@ -30,6 +32,7 @@ Langchain's
 LLM
 LLMBlock
 MCQ
+md
 Merlinite
 Mixtral
 MMLU

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -43,9 +43,13 @@ Release mechanics are done by a Release Manager identified for that release.
 The Release Manager is a member of the SDG Maintainers team that has agreed to take on these responsibilities.
 The Release Manager can change on a per-release basis.
 
-The following are the steps for how Y-stream and Z-stream releases gets cut.
+### Prepare CHANGELOG.md for the release
+
+In the `main` branch, move the appropriate unreleased items in the top level CHANGELOG.md to a section for the new release. And, audit commits in the release and add notes for any missed items. Ensure any changes to CHANGELOG.md also end up on the appropriate release branch, which may involve backporting changes as necessary.
 
 ### Y-Stream
+
+Follow these steps when creating a new Y-stream release:
 
 1. Determine a commit on the main branch that will serve as the basis for the next release - most of the time this should be the latest commit.
 1. Create a new release branch in the format `release-vX.Y` off of the determined commit (will match `main` if the latest commit is chosen).
@@ -56,6 +60,8 @@ The following are the steps for how Y-stream and Z-stream releases gets cut.
     - The `dev` mailing list
 
 ### Z-Stream
+
+Follow these steps when creating a new Z-stream release:
 
 1. Backport all relevant commits from `main` to the `release-vX.Y` branch.
     - It may also be the case you wish to update release branch first - if this approach is taken, ensure any relevant commits are subsequently backported to `main`


### PR DESCRIPTION
Add notes for how we should ensure CHANGELOG.md is updated when cutting a new release.