### PR TITLE
Update CHANGELOG.md for release v0.6.2

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -7,10 +7,12 @@ config:
   code-block-style: false
   no-duplicate-header: false
   single-trailing-newline: false
+  no-duplicate-heading: false
 globs:
   - "**/*.md"
 ignores:
   - ".github/**"
+  - ".tox/**"
   - "venv/**"
   - ".venv/**"
   - "**/testdata/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.6.2
+
+### Fixes
+
+* Fixed a bug in our version specification of `docling` and `docling_parse` dependencies that were causing new installs of InstructLab to pull in incompatible versions of these. We also fixed a similar bug in the `mypy` dependency, but that one only impacts developers of SDG as opposed to users of InstructLab.
+
 ## v0.6.1
 
 ### Fixes


### PR DESCRIPTION
Ensuring our release notes are accurate for the imminent release v0.6.2.