### PR TITLE
Fix logging the number of generated samples for each leaf node

### DIFF
--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -426,8 +426,8 @@ def generate_data(
             continue
         generated_data.append(new_generated_data)
 
-        logger.info("Generated %d samples", len(generated_data))
-        logger.debug("Generated data: %s", generated_data)
+        logger.info("Generated %d samples", len(new_generated_data))
+        logger.debug("Generated data: %s", new_generated_data)
 
         if is_knowledge:
             # generate mmlubench data for the current leaf node


### PR DESCRIPTION
We were logging the length of our `generated_data` list instead of the number of newly generated samples in each leaf node, causing confusion as this is typically 1, 2, 3, etc instead of 50, 500, 1000, etc that users would expect.

Fixes #227