### PR TITLE
Update URLs in `docs/dataset_formats.md` to point to the new InstructLab `scripts/test-data` files

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -5,8 +5,8 @@ Backport
 backported
 CLI
 codebase
-composable
 Composable
+composable
 config
 configs
 customizable
@@ -29,6 +29,7 @@ JSON
 Langchain's
 LLM
 LLMBlock
+mbta
 MCQ
 Merlinite
 Mixtral

--- a/docs/dataset_formats.md
+++ b/docs/dataset_formats.md
@@ -48,9 +48,17 @@ The fields in a knowledge contribution are:
 
 Examples of these files used in CI are found [here](https://github.com/instructlab/instructlab/tree/main/scripts/test-data):
 
-* [e2e-qna-freeform-skill](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/e2e-qna-freeform-skill.yaml)
-* [e2e-qna-grounded-skill](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/e2e-qna-grounded-skill.yaml)
-* [e2e-qna-knowledge](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/e2e-qna-knowledge.yaml)
+* Compositional skills
+  * Freeform
+    * [e2e-qna-freeform-palindrome-skill](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/compositional_skills/freeform/e2e-qna-freeform-palindrome-skill.yaml)
+    * [e2e-qna-freeform-siblings-skill](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/compositional_skills/freeform/e2e-qna-freeform-siblings-skill.yaml)
+  * Grounded
+    * [e2e-qna-grounded-employee-skill](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/compositional_skills/grounded/e2e-qna-grounded-employee-skill.yaml)
+    * [e2e-qna-grounded-punctuation-skill](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/compositional_skills/grounded/e2e-qna-grounded-punctuation.yaml)
+* Knowledge
+  * [e2e-qna-knowledge-mbta](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/knowledge/e2e-qna-knowledge-mbta.yaml)
+  * [e2e-qna-knowledge-phoenix](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/knowledge/e2e-qna-knowledge-phoenix.yaml)
+  * [e2e-qna-knowledge](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/knowledge/e2e-qna-knowledge.yaml)
 
 ### Pregenerated Dataset (Input)
 

--- a/docs/dataset_formats.md
+++ b/docs/dataset_formats.md
@@ -54,7 +54,7 @@ Examples of these files used in CI are found [here](https://github.com/instructl
     * [e2e-qna-freeform-siblings-skill](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/compositional_skills/freeform/e2e-qna-freeform-siblings-skill.yaml)
   * Grounded
     * [e2e-qna-grounded-employee-skill](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/compositional_skills/grounded/e2e-qna-grounded-employee-skill.yaml)
-    * [e2e-qna-grounded-punctuation-skill](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/compositional_skills/grounded/e2e-qna-grounded-punctuation.yaml)
+    * [e2e-qna-grounded-punctuation-skill](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/compositional_skills/grounded/e2e-qna-grounded-punctuation-skill.yaml)
 * Knowledge
   * [e2e-qna-knowledge-mbta](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/knowledge/e2e-qna-knowledge-mbta.yaml)
   * [e2e-qna-knowledge-phoenix](https://github.com/instructlab/instructlab/blob/main/scripts/test-data/knowledge/e2e-qna-knowledge-phoenix.yaml)


### PR DESCRIPTION
The `scripts/test-data` directory structure was modified in the [instructlab/instructlab](https://github.com/instructlab/instructlab) repo to accommodate more skill + knowledge files, which means we need to update the `scripts/test-data` URLs in `docs/dataset_formats.md` accordingly.