### PR TITLE
feat: update release-strategy to include discord

### DIFF
--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -52,6 +52,7 @@ The following are the steps for how Y-stream and Z-stream releases gets cut.
 1. Create a new release on GitHub targeting the release branch and using the latest Y-Stream tag as the previous release (e.g. `0.15.1` precedes `0.16.0`).
 1. Announce release via the following:
     - The `#sdg` channel on Slack
+    - The `#sdg` channel on Discord
     - The `dev` mailing list
 
 ### Z-Stream
@@ -61,4 +62,5 @@ The following are the steps for how Y-stream and Z-stream releases gets cut.
 1. Create a new release on GitHub targeting the release branch and using the previous Z-Stream tag as the previous release (e.g. `0.15.0` precedes `0.15.1`).
 1. If changes warrant an announcement, announce via the following:
     - The `#sdg` channel on Slack
+    - The `#sdg` channel on Discord
     - The `dev` mailing list


### PR DESCRIPTION
In order to facilliate the addition of Discord as a new chat platform, we will be mirroring
all announcements made regarding releases as currently happens on Slack to also take place
on Discord. This commit updates our policy document to reflect this change

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>