### PR TITLE
chore!: Update PyTorch to 2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ openai>=1.13.3,<2.0.0
 sentencepiece>=0.2.0
 tabulate>=0.9.0
 tenacity>=8.3.0,!=8.4.0
-torch>=2.3.0,<2.5.0
+torch>=2.3.0,<2.6.0
 transformers>=4.41.2
 xdg-base-dirs>=6.0.1


### PR DESCRIPTION
This change increases the upper version of PyTorch to allow version 2.5.

Resolves #462