### PR TITLE
Update CHANGELOG.md for v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Any users that were specifying custom pipeline configs (instead of using the def
 
 ### Fixes
 
+## v0.6.3
+
+### Fixes
+
+* The max version constraint of PyTorch in our requirements file was raised so that we don't prevent SDG users from using it PyTorch 2.5.
+
 ## v0.6.2
 
 ### Fixes


### PR DESCRIPTION
This just adds a note about relaxing PyTorch version constraints to our CHANGELOG.md in preparation for releasing v0.6.3.