### PR TITLE
chore: Change default temporary write directory in all e2e CI jobs from `tmpfs` to `/home/tmp`

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -26,6 +26,7 @@ concurrency:
 
 env:
   LC_ALL: en_US.UTF-8
+  TMPDIR: /home/tmp
 
 defaults:
   run:
@@ -81,6 +82,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
+          mkdir -p "${TMPDIR}"
           sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
 
       - name: Checkout instructlab/instructlab

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -12,6 +12,9 @@ on:
         required: true
         default: 'main'
 
+env:
+  TMPDIR: /home/tmp
+
 jobs:
   start-large-ec2-runner:
     runs-on: ubuntu-latest
@@ -57,6 +60,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
+          mkdir -p "${TMPDIR}"
           sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
 
       - name: Checkout instructlab/instructlab

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -26,6 +26,7 @@ concurrency:
 
 env:
   LC_ALL: en_US.UTF-8
+  TMPDIR: /home/tmp
 
 defaults:
   run:
@@ -81,6 +82,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
+          mkdir -p "${TMPDIR}"
           sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
 
       - name: Checkout instructlab/instructlab


### PR DESCRIPTION
This PR tackles the same issue originally identified in https://github.com/instructlab/instructlab/issues/2866, where we noticed intermittent OOM issues during some of our e2e CI jobs.

While I have not noticed any OOM issues recently in this repo, updating the default temporary write directory from `tmpfs` (aka `/tmp`) to `/home/tmp` should mitigate the risk of OOM errors occurring in our e2e CI jobs since we'll now theoretically have access to 100% of the available physical memory in our EBS volume, instead of only 50%.