### PR TITLE
RHELAI-2756 Adding Adaptive Throttling

### DIFF
--- a/src/instructlab/sdg/pipeline.py
+++ b/src/instructlab/sdg/pipeline.py
@@ -178,11 +178,11 @@ class Pipeline:
             max_workers=self.ctx.batch_num_workers, # Upper limit from config
             initial_workers=self.ctx.batch_num_workers//2, # Start at 50% of max
         )
-            
+
         if not input_splits:
             logger.warning("Input splits are empty. Returning empty dataset.")
-            return concatenate_datasets([])            
-        
+            return concatenate_datasets([])
+
         while input_splits:
             # Get the current number of workers from the throttler
             current_workers = throttler.get_workers()
@@ -205,7 +205,7 @@ class Pipeline:
                         output_splits.append(ds) # Store the successful result
                         checkpointer.checkpoint(ds) # Save progress
                         throttler.adjust_workers(success=True) # Increase workers on success
-                    
+
                     except PipelineBlockError as err:
                         root_exception = err.exception  # Access the underlying exception
 
@@ -217,11 +217,8 @@ class Pipeline:
                             # Non-retryable errors
                             logger.error("Non Retryable error in pipeline batch generation: %s", err)
                             throttler.adjust_workers(success=False)
-                    except Exception as generic_err:
-                        logger.error("Unexpected error in batch generation: %s", generic_err)
-                        throttler.adjust_workers(success=False)  # Adjust workers for unexpected errors
 
-        
+
         checkpointer.done()
         if pre_generated_data:
             output_splits.append(pre_generated_data)

--- a/src/instructlab/sdg/throttlers.py
+++ b/src/instructlab/sdg/throttlers.py
@@ -1,0 +1,31 @@
+import threading
+
+DEFAULT_TOLERANCE = 0.2  # Fraction to reduce workers on failure
+
+class AdaptiveThrottler:
+    def __init__(self, min_workers, max_workers, initial_workers, tolerance=DEFAULT_TOLERANCE):
+        self.min_workers = min_workers  # Lower limit of workers
+        self.max_workers = max_workers  # Upper limit of workers, same as num_cpus cli argument
+        self.current_workers = initial_workers  # Start with this number
+        self.tolerance = tolerance  # Reduce workers by this fraction on error
+        self.lock = threading.Lock()  # Ensure thread-safe updates
+
+    def adjust_workers(self, success=True):
+        """Adjust the number of workers based on success or failure."""
+        with self.lock:  # Use a lock to avoid race conditions in multi-threading
+            if success:
+                # Gradually increase workers up to max_workers
+                if self.current_workers < self.max_workers:
+                    self.current_workers += 1
+            else:
+                # Reduce workers by a fraction on failure, respecting min_workers
+                if self.current_workers > self.min_workers:
+                    self.current_workers = max(
+                        self.min_workers,
+                        int(self.current_workers * (1 - self.tolerance)),
+                    )
+
+    def get_workers(self):
+        """Get the current number of workers."""
+        with self.lock:
+            return self.current_workers


### PR DESCRIPTION
### Why Adaptive Throttling?
Fixes #424 
### The Problem:
If too many requests are sent concurrently to the server, it might:
- Run out of GPU memory (VRAM) or other resources.
- Fail to respond to requests within the timeout period.
- Reducing concurrency manually (batch_num_workers) is a workaround, but it's static and not adaptive to server conditions.

### The Solution:
- Monitor the server's behavior (e.g., response success or failure).
- Dynamically increase or decrease concurrency based on server feedback.

### Key Components in the Code
### The AdaptiveThrottler Class

This class encapsulates the logic for adjusting concurrency:

Parameters:
```
        min_workers: Minimum number of concurrent workers (never go below this).
        max_workers: Maximum allowed concurrent workers, matches the num_cpus from instructlab core.
        initial_workers: Starting number of workers, 50% of max to begin with.
        tolerance: Fraction to reduce workers when errors occur.
```