### PR TITLE
Clone the PR's merge branch vs head in e2e tests

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -96,7 +96,6 @@ jobs:
       - name: Checkout instructlab/sdg
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: "instructlab/sdg"
           path: "sdg"
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
@@ -105,8 +104,10 @@ jobs:
         if: ${{ github.event_name == 'pull_request_target' }}
         working-directory: ./sdg
         run: |
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }}
-          git checkout pr-${{ github.event.pull_request.number }}
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:pr-merge-${{ github.event.pull_request.number }}
+          git checkout pr-merge-${{ github.event.pull_request.number }}
+          git log -1 --format="%H %s"
+
 
       - name: Install ilab
         working-directory: ./instructlab

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -74,7 +74,6 @@ jobs:
       - name: Checkout instructlab/sdg
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: "instructlab/sdg"
           path: "sdg"
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
@@ -129,15 +128,17 @@ jobs:
         if: steps.check_pr.outputs.is_pr == 'true'
         working-directory: ./sdg
         run: |
-          gh pr checkout ${{ steps.check_pr.outputs.pr_or_branch }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          git fetch origin pull/${{ steps.check_pr.outputs.pr_or_branch }}/merge:pr-merge-${{ steps.check_pr.outputs.pr_or_branch }}
+          git checkout pr-merge-${{ steps.check_pr.outputs.pr_or_branch }}
+          git log -1 --format="%H %s"
 
       - name: Checkout branch
         if: steps.check_pr.outputs.is_pr == 'false'
         working-directory: ./sdg
         run: |
           git checkout ${{ steps.check_pr.outputs.pr_or_branch }}
+          git log -1 --format="%H %s"
+
 
       - name: Install ilab
         working-directory: ./instructlab

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -96,7 +96,6 @@ jobs:
       - name: Checkout instructlab/sdg
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: "instructlab/sdg"
           path: "sdg"
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
@@ -105,8 +104,9 @@ jobs:
         if: github.event_name == 'pull_request_target'
         working-directory: ./sdg
         run: |
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }}
-          git checkout pr-${{ github.event.pull_request.number }}
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:pr-merge-${{ github.event.pull_request.number }}
+          git checkout pr-merge-${{ github.event.pull_request.number }}
+          git log -1 --format="%H %s"
 
       - name: Install ilab
         working-directory: ./instructlab


### PR DESCRIPTION
This configures actions/checkout to clone the PR's merge branch (instead of the PR's head), to align with how unit/functional tests work and ensure that all of our tests are testing against the same codebase - the state of the code as it would look after the PR merges, to get an accurate picture of whether things will pass if this merges or not.

Related to #482