### PR TITLE
Adding Batching After Every Block

### DIFF
--- a/src/instructlab/sdg/blocks/llmblock.py
+++ b/src/instructlab/sdg/blocks/llmblock.py
@@ -326,11 +326,11 @@ class ConditionalLLMBlock(LLMBlock):
         if isinstance(self.prompt_template, dict):
             return (
                 self.prompt_template[sample[self.selector_column_name]]
-                .render(sample)
+                .format(**sample)
                 .strip()
             )
 
-        return self.prompt_template.render(sample).strip()
+        return self.prompt_template.format(**sample).strip()
 
     def _validate(self, prompt_template: str, input_dict: Dict[str, Any]) -> bool:
         if isinstance(prompt_template, dict):

--- a/src/instructlab/sdg/blocks/llmblock.py
+++ b/src/instructlab/sdg/blocks/llmblock.py
@@ -326,11 +326,11 @@ class ConditionalLLMBlock(LLMBlock):
         if isinstance(self.prompt_template, dict):
             return (
                 self.prompt_template[sample[self.selector_column_name]]
-                .format(**sample)
+                .render(sample)
                 .strip()
             )
 
-        return self.prompt_template.format(**sample).strip()
+        return self.prompt_template.render(sample).strip()
 
     def _validate(self, prompt_template: str, input_dict: Dict[str, Any]) -> bool:
         if isinstance(prompt_template, dict):

--- a/src/instructlab/sdg/pipeline.py
+++ b/src/instructlab/sdg/pipeline.py
@@ -199,7 +199,7 @@ class Pipeline:
                 logger.info("Running block: %s", block_name)
 
                 # Check if batching is enabled
-                if self.ctx.batch_size is None or not self.ctx.batching_enabled:
+                if not self.ctx.batching_enabled:
                     logger.info(
                         "Batching disabled; processing block '%s' single-threaded.",
                         block_name,

--- a/src/instructlab/sdg/pipeline.py
+++ b/src/instructlab/sdg/pipeline.py
@@ -200,7 +200,10 @@ class Pipeline:
 
                 # Check if batching is enabled
                 if self.ctx.batch_size is None or not self.ctx.batching_enabled:
-                    logger.info("Batching disabled; processing block '%s' single-threaded.", block_name)
+                    logger.info(
+                        "Batching disabled; processing block '%s' single-threaded.",
+                        block_name,
+                    )
                     dataset = block.generate(dataset)
                 else:
                     # Split the dataset into batches
@@ -217,7 +220,9 @@ class Pipeline:
                     return dataset
 
                 # Remove unnecessary columns if specified
-                drop_columns_in_ds = [e for e in drop_columns if e in dataset.column_names]
+                drop_columns_in_ds = [
+                    e for e in drop_columns if e in dataset.column_names
+                ]
                 if drop_columns_in_ds:
                     dataset = dataset.remove_columns(drop_columns_in_ds)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -101,6 +101,7 @@ def test_pipeline_batching_order_correct(sample_dataset, threaded_ctx):
         res = Pipeline(threaded_ctx, "", pipe_cfg).generate(sample_dataset)
     assert res.to_list() == [{"foo": i * 2} for i in range(10)]
 
+
 def test_pipeline_batching_after_each_block(sample_dataset, threaded_ctx):
     """Test that batching occurs after each block in the pipeline."""
 
@@ -110,15 +111,15 @@ def test_pipeline_batching_after_each_block(sample_dataset, threaded_ctx):
 
         def generate(self, dataset):
             # Assert that the dataset entering Block 1 is properly batched
-            assert len(dataset) <= self.ctx.batch_size, (
-                f"Dataset size {len(dataset)} entering block 1 exceeds batch size {self.ctx.batch_size}"
-            )
+            assert (
+                len(dataset) <= self.ctx.batch_size
+            ), f"Dataset size {len(dataset)} entering block 1 exceeds batch size {self.ctx.batch_size}"
             # Simulate dataset explosion in Block 1
 
             exploded_data = []
             for _ in range(10):  # Repeat each entry 10 times
                 exploded_data.extend(dataset)
-            
+
             # Create a new Dataset from the exploded data
             output = Dataset.from_list(exploded_data)
 
@@ -130,9 +131,9 @@ def test_pipeline_batching_after_each_block(sample_dataset, threaded_ctx):
 
         def generate(self, dataset):
             # Assert that the dataset entering Block 2 is properly batched (this will fail if batching is not done after each block)
-            assert len(dataset) <= self.ctx.batch_size, (
-                f"Dataset size {len(dataset)} entering block 2 exceeds batch size {self.ctx.batch_size}"
-            )
+            assert (
+                len(dataset) <= self.ctx.batch_size
+            ), f"Dataset size {len(dataset)} entering block 2 exceeds batch size {self.ctx.batch_size}"
             return dataset
 
     # Define the pipeline configuration with two blocks
@@ -155,11 +156,16 @@ def test_pipeline_batching_after_each_block(sample_dataset, threaded_ctx):
         result = Pipeline(threaded_ctx, "", pipe_cfg).generate(sample_dataset)
     # Assertions for the final output dataset:
     # 1. Check the final dataset length is the expected value
-    expected_len = len(sample_dataset) * 10  # Since Block 1 multiplies the dataset by 10
-    assert len(result) == expected_len, f"Expected dataset length {expected_len}, but got {len(result)}"
+    expected_len = (
+        len(sample_dataset) * 10
+    )  # Since Block 1 multiplies the dataset by 10
+    assert (
+        len(result) == expected_len
+    ), f"Expected dataset length {expected_len}, but got {len(result)}"
 
     # 2. Check the dataset features: Ensure the feature structure is consistent with the input
-    assert 'foo' in result[0], "Feature 'foo' not found in the final dataset"
+    assert "foo" in result[0], "Feature 'foo' not found in the final dataset"
+
 
 ## Pipeline Error Handling ##
 


### PR DESCRIPTION
### The Problem:

Resolves #480, related to #424 

### Key Changes Implemented

### Re-batch After Each Block:

After processing the dataset through a block, split it into batches based on the current batch_size (reuses `._split_dataset` within class `Pipeline`)

### Sequential Execution for Each Block:
Process batches sequentially within each block, and does not spawn any more threads of execution.

### Recombine Batch Outputs:
Combine the processed batches back into a single dataset before sending it to the next block. (reuses `concatenate_datasets()`)
