### PR TITLE
use render method for jinja template, add unit tests

### DIFF
--- a/src/instructlab/sdg/blocks/llmblock.py
+++ b/src/instructlab/sdg/blocks/llmblock.py
@@ -323,14 +323,15 @@ class ConditionalLLMBlock(LLMBlock):
                 )
 
     def _format_prompt(self, sample: Dict) -> str:
+        # If prompt_template is a dict, use the selector column to select the correct template
         if isinstance(self.prompt_template, dict):
             return (
                 self.prompt_template[sample[self.selector_column_name]]
-                .format(**sample)
+                .render(sample)
                 .strip()
             )
-
-        return self.prompt_template.format(**sample).strip()
+        # Otherwise, use the sample to render the prompt without any selection
+        return self.prompt_template.render(sample).strip()
 
     def _validate(self, prompt_template: str, input_dict: Dict[str, Any]) -> bool:
         if isinstance(prompt_template, dict):

--- a/tests/test_llmblock.py
+++ b/tests/test_llmblock.py
@@ -10,6 +10,7 @@ import unittest
 from datasets import Dataset, Features, Value
 from httpx import URL
 from openai import InternalServerError, NotFoundError
+from jinja2 import Template, StrictUndefined, UndefinedError
 import pytest
 
 # First Party
@@ -120,9 +121,9 @@ class TestLLMBlockWithRealConfigs(unittest.TestCase):
                     output_cols=[],
                 )
                 sample = {"foo": "bar"}
-                assert not block._validate(
-                    block.prompt_template, sample
-                ), f"{config_type} config {config_yaml.name} validated even though it was given a sample with none of the expected fields"
+                assert not block._validate(block.prompt_template, sample), (
+                    f"{config_type} config {config_yaml.name} validated even though it was given a sample with none of the expected fields"
+                )
 
     def test_simple_generate_qa_with_valid_sample(self):
         config_yaml = os.path.join(
@@ -307,6 +308,80 @@ class TestConditionalLLMBlock(unittest.TestCase):
         assert block._validate(
             block.prompt_template, {"selector": "_A_", "var1": "foo", "var2": "bar"}
         )
+
+    def test_format_prompt_with_jinja_templates(self, mock_load_config):
+        mock_load_config.return_value = {
+            "system": "{{var1}} {{var2}}",
+            "introduction": "introduction",
+            "principles": "principles",
+            "examples": "examples",
+            "generation": "generation",
+        }
+        # Create an instance of the block
+        block = ConditionalLLMBlock(
+            ctx=self.mock_ctx,
+            pipe=self.mock_pipe,
+            block_name="gen_knowledge",
+            config_paths=[["/foo/bar", "_A_"]],
+            output_cols=[],
+            selector_column_name="selector",
+        )
+
+        # Mock prompt_template as a Jinja template
+        block.prompt_template = {
+            "case1": Template("Hello, {{ name }}!", undefined=StrictUndefined),
+            "case2": Template("Goodbye, {{ name }}.", undefined=StrictUndefined),
+        }
+
+        # Sample input
+        sample1 = {"selector": "case1", "name": "Alice"}
+        sample2 = {"selector": "case2", "name": "Bob"}
+
+        # Test case 1
+        result1 = block._format_prompt(sample1)
+        self.assertEqual(result1, "Hello, Alice!")
+
+        # Test case 2
+        result2 = block._format_prompt(sample2)
+        self.assertEqual(result2, "Goodbye, Bob.")
+
+        # Verify error with missing keys in sample
+        with self.assertRaises(UndefinedError):
+            block._format_prompt({"selector": "case1"})  # 'name' is missing
+
+    def test_format_prompt_without_selector(self, mock_load_config):
+        mock_load_config.return_value = {
+            "system": "{{var1}} {{var2}}",
+            "introduction": "introduction",
+            "principles": "principles",
+            "examples": "examples",
+            "generation": "generation",
+        }
+        # Create an instance of the block
+        block = ConditionalLLMBlock(
+            ctx=self.mock_ctx,
+            pipe=self.mock_pipe,
+            block_name="gen_knowledge",
+            config_paths=[["/foo/bar", "_A_"]],
+            output_cols=[],
+            selector_column_name=None,  # No selector
+        )
+
+        # Mock prompt_template as a Jinja template
+        block.prompt_template = Template(
+            "Welcome, {{ user }}!", undefined=StrictUndefined
+        )
+
+        # Sample input
+        sample = {"user": "Connor"}
+
+        # Test
+        result = block._format_prompt(sample)
+        self.assertEqual(result, "Welcome, Connor!")
+
+        # Verify error with missing keys in sample
+        with self.assertRaises(UndefinedError):
+            block._format_prompt({})  # 'user' is missing
 
 
 @patch("src.instructlab.sdg.blocks.block.Block._load_config")

--- a/tests/test_llmblock.py
+++ b/tests/test_llmblock.py
@@ -9,8 +9,8 @@ import unittest
 # Third Party
 from datasets import Dataset, Features, Value
 from httpx import URL
+from jinja2 import StrictUndefined, Template, UndefinedError
 from openai import InternalServerError, NotFoundError
-from jinja2 import Template, StrictUndefined, UndefinedError
 import pytest
 
 # First Party
@@ -121,9 +121,9 @@ class TestLLMBlockWithRealConfigs(unittest.TestCase):
                     output_cols=[],
                 )
                 sample = {"foo": "bar"}
-                assert not block._validate(block.prompt_template, sample), (
-                    f"{config_type} config {config_yaml.name} validated even though it was given a sample with none of the expected fields"
-                )
+                assert not block._validate(
+                    block.prompt_template, sample
+                ), f"{config_type} config {config_yaml.name} validated even though it was given a sample with none of the expected fields"
 
     def test_simple_generate_qa_with_valid_sample(self):
         config_yaml = os.path.join(


### PR DESCRIPTION
Fixes #490 

### Problem

We changed from using simple python string templates to jinja templates, but missed a few places (`ConditionalLLMBlock`) to account for this change, which went unnoticed due to missing test coverage for this.

### The Solution

- Addresses the problem (change from `.format()` to `.render()`, treating the input to `_format_prompt()` as a jinja `Template`
- Adds two unit tests `test_format_prompt_with_jinja_templates` and `test_format_prompt_without_selector` that test the behavior of `Template.render()` based on the inputs. These tests will fail if there are parts of the code that call to `_format_prompt()` with a python string argument.