### PR TITLE
Make everything but client optional on PipelineContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Upcoming v0.8.x
+
+### Features
+
+### LLMBlocks can now specify `model_family` or `model_id` in their config
+
+Each `LLMBlock` in a `Pipeline` can now specify `model_family` or `model_id` in their yaml configuration to set the values to use for these blocks, as opposed to setting this for the entire `Pipeline` in the `PipelineContext` object. This is useful for the cases where multiple `LLMBlocks` exist in the same `Pipeline` where each one uses a different model.
+
+#### Fewer required parameters for `PipelineContext`
+
+The parameters `model_family`, `model_id`, and `num_instructions_to_generate` are no longer required in `PipelineContext` objects. They used to be required, and if passed in will still get used as before. However, they can now be omitted if your `Pipeline` contains no `LLMBlock` entries or if your `LLMBlock` config specifies these values in the `Pipeline` yaml.
+
 ## v0.7.0
 
 ### Features

--- a/docs/examples/multiple_llms/README.md
+++ b/docs/examples/multiple_llms/README.md
@@ -1,0 +1,5 @@
+# Multiple LLMs in a single Pipeline
+
+To create a `Pipeline` that uses multiple different LLMs for inference, each `LLMBlock` in the `Pipeline` yaml should specify a `model_family` (to indicate which set of prompts to use) and a `model_id` (corresponding to the id of this model in the deployed inference server). For more control over the prompting, a direct `model_prompt` may be used in place of `model_family` to specify the exact prompt to use as opposed to choosing a generic one for that model family.
+
+See `pipeline.yaml` in this directory for an example of a Pipeline that calls into 3 separate LLMs.

--- a/docs/examples/multiple_llms/pipeline.yaml
+++ b/docs/examples/multiple_llms/pipeline.yaml
@@ -1,0 +1,34 @@
+version: "1.0"
+blocks:
+  - name: model_one
+    type: LLMBlock
+    config:
+      model_family: mixtral
+      model_id: Mixtral-8x7B-Instruct-v0.1
+      config_path: model_one_config.yaml
+      output_cols:
+        - column_one
+      gen_kwargs:
+        max_tokens: 2048
+
+  - name: model_two
+    type: LLMBlock
+    config:
+      model_family: granite
+      model_id: granite-7b-lab
+      config_path: model_two_config.yaml
+      output_cols:
+        - column_two
+      gen_kwargs:
+        max_tokens: 512
+
+  - name: model_three
+    type: LLMBlock
+    config:
+      model_id: granite-7b-lab
+      model_prompt: <s> [INST] {prompt} [/INST]
+      config_path: model_three_config.yaml
+      output_cols:
+        - column_three
+      gen_kwargs:
+        max_tokens: 5

--- a/scripts/validate_pipelines.py
+++ b/scripts/validate_pipelines.py
@@ -30,6 +30,7 @@ def main():
         schema = json.load(file)
 
     yaml_files = glob.glob("src/instructlab/sdg/pipelines/**/*.yaml", recursive=True)
+    yaml_files.extend(glob.glob("docs/examples/**/pipeline.yaml", recursive=True))
     all_valid = True
     for yaml_file in yaml_files:
         print("=======================================================")

--- a/src/instructlab/sdg/pipeline.py
+++ b/src/instructlab/sdg/pipeline.py
@@ -16,7 +16,7 @@ import yaml
 
 # First Party
 from instructlab.sdg.checkpointing import Checkpointer
-from instructlab.sdg.utils import models, pandas
+from instructlab.sdg.utils import pandas
 
 # Local
 from .blocks import llmblock
@@ -61,18 +61,15 @@ class PipelineContext:  # pylint: disable=too-many-instance-attributes
     DEFAULT_DATASET_NUM_PROCS = 8
 
     client: OpenAI
-    model_family: str
-    model_id: str
-    num_instructions_to_generate: int
+    model_family: Optional[str] = None
+    model_id: Optional[str] = None
+    num_instructions_to_generate: Optional[int] = None
     dataset_num_procs: Optional[int] = DEFAULT_DATASET_NUM_PROCS
     checkpoint_dir: Optional[str] = None
     save_freq: Optional[int] = 1
     max_num_tokens: Optional[int] = llmblock.DEFAULT_MAX_NUM_TOKENS
     batch_size: int = DEFAULT_BATCH_SIZE
     batch_num_workers: Optional[int] = None
-
-    def __post_init__(self):
-        self.model_family = models.get_model_family(self.model_family, self.model_id)
 
     @property
     def batching_enabled(self) -> bool:

--- a/src/instructlab/sdg/pipelines/schema/v1.json
+++ b/src/instructlab/sdg/pipelines/schema/v1.json
@@ -94,6 +94,12 @@
                       "type": "string"
                     }
                   },
+                  "model_id": {
+                    "type": "string"
+                  },
+                  "model_family": {
+                    "type": "string"
+                  },
                   "model_prompt": {
                     "type": "string"
                   },
@@ -176,6 +182,12 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "model_id": {
+                    "type": "string"
+                  },
+                  "model_family": {
+                    "type": "string"
                   },
                   "model_prompt": {
                     "type": "string"

--- a/tests/functional/test_granular_api.py
+++ b/tests/functional/test_granular_api.py
@@ -91,6 +91,7 @@ class TestGranularAPI(unittest.TestCase):
             input_dir=preprocessed_dir,
             output_dir=generated_dir,
             pipeline=pipeline_dir,
+            model_id="mock",
             num_cpus=1,  # Test is faster running on a single CPU vs forking
             batch_size=0,  # Disable batch for tiny dataset and fastest test
         )

--- a/tests/testdata/custom_block.py
+++ b/tests/testdata/custom_block.py
@@ -16,7 +16,7 @@ class EchoBlock(Block):
         return samples
 
 
-pipeline_context = PipelineContext(None, "mixtral", "my_model", 5)
+pipeline_context = PipelineContext(None)
 pipeline_yaml = pathlib.Path(__file__).parent.joinpath("custom_block_pipeline.yaml")
 pipeline = Pipeline.from_file(pipeline_context, pipeline_yaml)
 input_ds = Dataset.from_list(


### PR DESCRIPTION
This makes model_family, model_id, and num_instructions_to_generate optional on PipelineContext instead of required. This should be a backwards-compatible change, and includes tests that verify passing the previously-required parameters into PipelineContext work as expected. This is a move towards supporting and expecting Pipelines that have LLMBlocks that may use different model families or different model ids.

If a Block's yaml config specifies a model_family or model_id and none is set on the PipelineContext, then the Block's values will get used. However, if these are set on the PipelineContext, they're treated as overrides and will override the values for all Blocks in this Pipeline. This behavior emulates the previous behavior, but we should steer users away from ever setting model_id or model_family on a PipelineContext if the Pipeline contains multiple LLMBlock entries.

Fixes #511