### PR TITLE
Add Python 3.12 to our unit and functional tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,10 +45,13 @@ jobs:
         python:
           - "3.10"
           - "3.11"
+          - "3.12"
         platform:
           - "ubuntu-latest"
         include:
           - python: "3.11"
+            platform: "macos-latest"
+          - python: "3.12"
             platform: "macos-latest"
     steps:
       - name: "Harden Runner"

--- a/tox.ini
+++ b/tox.ini
@@ -93,5 +93,6 @@ commands =
 
 [gh]
 python =
+    3.12 = py312-{unitcov, functional}
     3.11 = py311-{unitcov, functional}
     3.10 = py310-{unitcov, functional}


### PR DESCRIPTION
To prepare SDG for supporting Python 3.12, this adds Python 3.12 to our unit and functional testing matrix alongside our Python 3.11 and 3.10 tests.

This is NOT running the `ilab` end-to-end workflow with Python 3.12, as InstructLab does not yet support Python 3.11.