### PR TITLE
Add missing pipeline schema for IterBlock

### DIFF
--- a/src/instructlab/sdg/pipelines/schema/v1.json
+++ b/src/instructlab/sdg/pipelines/schema/v1.json
@@ -348,6 +348,20 @@
                     "type": "string"
                   }
                 }
+              },
+              {
+                "type": "object",
+                "description": "IterBlock",
+                "required": ["num_iters", "block_type"],
+                "additionalProperties": true,
+                "properties": {
+                  "num_iters": {
+                    "type": "number"
+                  },
+                  "block_type": {
+                    "type": "string"
+                  }
+                }
               }
             ]
           }


### PR DESCRIPTION
When reconciling the SDG code, we forgot to add a schema entry for IterBlock. This does that, which will fix the CI failure hit in PR #518