### PR TITLE
Disable medium test by default with older release branches

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -12,7 +12,6 @@ on:
   pull_request_target:
     branches:
       - main
-      - release-*
     paths:
       # note this should match the merging criteria in 'mergify.yml'
       - '**.py'


### PR DESCRIPTION
Avoids more complicated changes to avoid using HF_TOKEN.