### PR TITLE
Don't require secrets in medium e2e test

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -139,9 +139,6 @@ jobs:
   
       - name: Run e2e test
         working-directory: ./instructlab
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           . venv/bin/activate
           ./scripts/e2e-ci.sh -m


### PR DESCRIPTION
This removes the need to have any secrets in the medium e2e test itself, simplifying the setup across repos as multiple repositories run this job and it's tedious to have to sync those secrets in multiple places.

Note that the workflow itself still uses secrets to spin up the EC2 runners, but the actual e2e test job no longer uses any secrets.