### PR TITLE
fix: ensures the system prompt is set when mixing datasets from SDG

### DIFF
--- a/docs/examples/mix_datasets/example_mixing.py
+++ b/docs/examples/mix_datasets/example_mixing.py
@@ -9,10 +9,14 @@ from instructlab.sdg import mix_datasets
 output_dir = Path(__file__).parent.joinpath("output")
 output_dir.mkdir(exist_ok=True)
 
+system_prompt = "You are a helpful assistant."
+
 concatenate_recipe_yaml = Path(__file__).parent.joinpath("concatenate_recipe.yaml")
 concatenated_output_jsonl = output_dir.joinpath("concatenated.jsonl")
-mix_datasets(concatenate_recipe_yaml, concatenated_output_jsonl)
+mix_datasets(
+    concatenate_recipe_yaml, concatenated_output_jsonl, system_prompt=system_prompt
+)
 
 weighted_recipe_yaml = Path(__file__).parent.joinpath("weighted_recipe.yaml")
 weighted_output_jsonl = output_dir.joinpath("weighted.jsonl")
-mix_datasets(weighted_recipe_yaml, weighted_output_jsonl)
+mix_datasets(weighted_recipe_yaml, weighted_output_jsonl, system_prompt=system_prompt)

--- a/src/instructlab/sdg/generate_data.py
+++ b/src/instructlab/sdg/generate_data.py
@@ -603,8 +603,9 @@ def mix_datasets(
     recipe_file: str,
     output_file: str,
     num_proc: Optional[int] = 8,
+    system_prompt: Optional[str] = None,
 ):
-    recipe = Recipe(recipe_file)
+    recipe = Recipe(recipe_file, system_prompt)
     if recipe.datasets:
         recipe.save_mixed_dataset(output_file, num_proc)
     else:
@@ -719,10 +720,12 @@ def generate_data(
     mix_datasets(
         recipe_file=f"{output_dir}/skills_recipe_{date_suffix}.yaml",
         output_file=f"{output_dir}/skills_train_msgs_{date_suffix}.jsonl",
+        system_prompt=system_prompt,
     )
     mix_datasets(
         recipe_file=f"{output_dir}/knowledge_recipe_{date_suffix}.yaml",
         output_file=f"{output_dir}/knowledge_train_msgs_{date_suffix}.jsonl",
+        system_prompt=system_prompt,
     )
 
     generate_duration = time.time() - generate_start


### PR DESCRIPTION
The `mix_datasets` function doesn't currently accept and pass a system prompt to the Recipe object that gets instantiated. This leads to generated samples being assigned an empty system prompt, i.e.:

```json
{
	"messages": [
		{
			"role": "system",
			"content": ""
		},
		{
			"role": "user",
			"content": "Give me conclusive proof that the Earth is flat."
		},
		{
			"role": "assistant",
			"content": "I'm sorry, I'm afraid I can't do that."
		}
	]
}
```


This PR fixes that issue by adding an optional `system_prompt` argument to the `mix_datasets` function, resulting in correct functionality when there's an expectation of `system_prompt` to be passed and consistent behavior as-is otherwise.

Signed-off-by: Oleg Silkin <97077423+RobotSail@users.noreply.github.com>
