### PR TITLE
Only use docling[tesserocr] on non-Macs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 click>=8.1.7,<9.0.0
 datasets>=2.18.0,<3.0.0
-docling[tesserocr]>=2.4.2,<=2.8.3
+docling[tesserocr]>=2.4.2,<=2.8.3; sys_platform != 'darwin'
+docling>=2.4.2,<=2.8.3; sys_platform == 'darwin'
 docling-parse>=2.0.0,<3.0.0
 GitPython>=3.1.42,<4.0.0
 gguf>=0.6.0


### PR DESCRIPTION
GitHub Mac runners recently have issues building docling[tesserocr]. Since we really only want to use tesseract for OCR on Linux, adjust our requirements.txt to clarify that and just use regular docling on Macs.