### PR TITLE
Allow multiple OpenAI clients per Pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### Features
 
+### Pipelines can now have LLMBlocks with different OpenAI clients
+
+For advanced use-cases, PipelineContext now accepts a `clients` dictionary of string to OpenAI client mappings. The special string of "default" sets the OpenAI client used for LLMBlocks by default, but individual LLMBlocks can override the client used by the `client` parameter in their yaml config.
+
+Backwards-compatibility is maintained for Pipelines that only need a single client, where setting the `client` property on PipelineContext objects just sets the default client in the `clients` dictionary automatically.
+
 ### LLMBlocks can now specify `model_family` or `model_id` in their config
 
 Each `LLMBlock` in a `Pipeline` can now specify `model_family` or `model_id` in their yaml configuration to set the values to use for these blocks, as opposed to setting this for the entire `Pipeline` in the `PipelineContext` object. This is useful for the cases where multiple `LLMBlocks` exist in the same `Pipeline` where each one uses a different model.

--- a/docs/examples/multiple_llm_clients/README.md
+++ b/docs/examples/multiple_llm_clients/README.md
@@ -1,0 +1,5 @@
+# Multiple LLM clients in a single Pipeline
+
+For advanced use-cases, PipelineContext accepts a `clients` dictionary of string to OpenAI client mappings. The special string of "default" sets the OpenAI client used for LLMBlocks by default, but individual LLMBlocks can override the client used by the `client` parameter in their yaml config.
+
+See `pipeline.yaml` in this directory for an example of a Pipeline that uses different clients per `LLMBlock`.

--- a/docs/examples/multiple_llm_clients/llm_config.yaml
+++ b/docs/examples/multiple_llm_clients/llm_config.yaml
@@ -1,0 +1,16 @@
+system: You are a helpful AI assistant.
+
+introduction: |
+  Repeat the document below back to me verbatim.
+
+principles: |
+  Do not change anything.
+
+examples: ""
+
+generation: |
+  Document:
+  {{document}}
+
+start_tags: [""]
+end_tags: [""]

--- a/docs/examples/multiple_llm_clients/pipeline.yaml
+++ b/docs/examples/multiple_llm_clients/pipeline.yaml
@@ -1,0 +1,44 @@
+version: "1.0"
+blocks:
+  # This uses the default client, since we don't specify one
+  - name: default_client
+    type: LLMBlock
+    config:
+      model_family: mixtral
+      model_id: Mixtral-8x7B-Instruct-v0.1
+      config_path: llm_config.yaml
+      output_cols:
+        - column_one
+
+  # We can also explicitly specify the default client
+  - name: also_default_client
+    type: LLMBlock
+    config:
+      client: default
+      model_family: mixtral
+      model_id: Mixtral-8x7B-Instruct-v0.1
+      config_path: llm_config.yaml
+      output_cols:
+        - column_two
+
+  # This uses the "server_a" client explicitly
+  - name: server_a_client
+    type: LLMBlock
+    config:
+      client: server_a
+      model_family: granite
+      model_id: granite-7b-lab
+      config_path: llm_config.yaml
+      output_cols:
+        - column_three
+
+  # This uses the "server_b" client explicitly
+  - name: server_b_client
+    type: LLMBlock
+    config:
+      client: server_b
+      model_family: granite
+      model_id: granite-7b-lab
+      config_path: llm_config.yaml
+      output_cols:
+        - column_four

--- a/src/instructlab/sdg/pipelines/schema/v1.json
+++ b/src/instructlab/sdg/pipelines/schema/v1.json
@@ -103,6 +103,9 @@
                   "model_prompt": {
                     "type": "string"
                   },
+                  "client": {
+                    "type": "string"
+                  },
                   "parser_kwargs": {
                     "type": "object",
                     "properties": {
@@ -190,6 +193,9 @@
                     "type": "string"
                   },
                   "model_prompt": {
+                    "type": "string"
+                  },
+                  "client": {
                     "type": "string"
                   },
                   "selector_column_name": {

--- a/tests/functional/test_examples.py
+++ b/tests/functional/test_examples.py
@@ -2,6 +2,7 @@
 
 # Standard
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 import shlex
 import shutil
 import subprocess
@@ -11,6 +12,7 @@ import sys
 from docling.document_converter import DocumentConverter
 
 # First Party
+from instructlab.sdg.pipeline import Pipeline, PipelineContext, _lookup_block_type
 from instructlab.sdg.utils.json import jlload
 
 
@@ -74,3 +76,29 @@ def test_example_iterblock(tmp_path: Path, examples_path: Path):
     output = jlload(output_jsonl)
     assert len(output) == 5
     assert output[4]["baz"] == "bar"
+
+
+def test_example_multiple_llm_clients(examples_path: Path):
+    pipeline_path = examples_path.joinpath("multiple_llm_clients", "pipeline.yaml")
+    default_client = MagicMock()
+    server_a_client = MagicMock()
+    server_b_client = MagicMock()
+    context = PipelineContext(
+        clients={
+            "default": default_client,
+            "server_a": server_a_client,
+            "server_b": server_b_client,
+        }
+    )
+    pipeline = Pipeline.from_file(context, pipeline_path)
+    blocks = []
+    for block_prop in pipeline.chained_blocks:
+        block_name = block_prop["name"]
+        block_type = _lookup_block_type(block_prop["type"])
+        block_config = block_prop["config"]
+        block = block_type(pipeline.ctx, pipeline, block_name, **block_config)
+        blocks.append(block)
+    assert blocks[0].client == default_client
+    assert blocks[1].client == default_client
+    assert blocks[2].client == server_a_client
+    assert blocks[3].client == server_b_client

--- a/tests/test_default_pipeline_configs.py
+++ b/tests/test_default_pipeline_configs.py
@@ -2,7 +2,7 @@
 
 # Standard
 from importlib import resources
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import unittest
 
 # Third Party
@@ -53,7 +53,7 @@ class TestDefaultPipelineConfigs(unittest.TestCase):
 
     def test_pipeline_from_config(self):
         ctx = PipelineContext(
-            client=None,
+            client=MagicMock(),
             model_family="mixtral",
             model_id="model",
             num_instructions_to_generate=1,


### PR DESCRIPTION
This change allows a user to construct a PipelineContext with multiple OpenAI clients, such as:

```python
PipelineContext(
    clients={
        "default": OpenAI(base_url="https://foo.local"),
        "server_a": OpenAI(base_url="https://server_a.local"),
        "server_b": OpenAI(base_url="https://server_b.local"),
    }
)
```

And then, within the pipeline yaml, choose which client to apply to which LLMBlock via a new `client` key, such as:

```yaml
version: "1.0"
blocks:
  - name: server_a_client
    type: LLMBlock
    config:
      client: server_a
      ...

  - name: server_b_client
    type: LLMBlock
    config:
      client: server_b
      ...
```

See `docs/examples/multiple_llm_clients` for more details and a full example.

Resolves #521