### PR TITLE
Remove the max version from our datasets dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 click>=8.1.7,<9.0.0
-datasets>=2.18.0,<3.0.0
+datasets>=2.18.0
 docling[tesserocr]>=2.4.2,<=2.8.3; sys_platform != 'darwin'
 docling>=2.4.2,<=2.8.3; sys_platform == 'darwin'
 docling-parse>=2.0.0,<3.0.0


### PR DESCRIPTION
We're using a fairly limited API surface of datasets that doesn't intersect with any breaking changes they had in the last major release, so remove this max version cap.

Fixes #580