### PR TITLE
Fix typo in mergify config for functional-gpu-small

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -67,7 +67,7 @@ pull_request_rules:
         - or:
           - files~=\.py$
           - files=pyproject.toml
-          - files=^requirements.*\.txt$
+          - files~=^requirements.*\.txt$
           - files=.github/workflows/functional-gpu-nvidia-t4-x1.yml
       - and:
         - -files~=\.py$


### PR DESCRIPTION
"files=..." to "files~=..." because it uses a regex