### PR TITLE
Unpin submodlib-py and remove linux only install constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ openai>=1.13.3,<2.0.0
 numba
 sentencepiece>=0.2.0
 # Note: this dependency has to be built from source
-submodlib-py==0.0.1; sys_platform == 'linux'
+submodlib-py==0.0.2
 tabulate>=0.9.0
 
 # Note: this dependency goes along with langchain-text-splitters and may be

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ openai>=1.13.3,<2.0.0
 numba
 sentencepiece>=0.2.0
 # Note: this dependency has to be built from source
-submodlib-py==0.0.2
+submodlib-py
 tabulate>=0.9.0
 
 # Note: this dependency goes along with langchain-text-splitters and may be


### PR DESCRIPTION
Since there is a new `0.0.2` release tag from `submodlib-py`, remove requirement versioning pin and remove linux-only requirement (as 0.0.2 supports MacOS builds)