### PR TITLE
Disable the e2e-small CI tests

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -44,20 +44,20 @@ pull_request_rules:
         - -files=.github/workflows/e2e-nvidia-l4-x1.yml
 
     # e2e small workflow
-    - or:
-      - and:
-        # note this should match the triggering criteria in 'e2e-nvidia-t4-x1.yml'
-        - check-success~=e2e-small-workflow-complete
-        - or:
-          - files~=\.py$
-          - files=pyproject.toml
-          - files~=^requirements.*\.txt$
-          - files=.github/workflows/e2e-nvidia-t4-x1.yml
-      - and:
-        - -files~=\.py$
-        - -files=pyproject.toml
-        - -files~=^requirements.*\.txt$
-        - -files=.github/workflows/e2e-nvidia-t4-x1.yml
+    # - or:
+    #   - and:
+    #     # note this should match the triggering criteria in 'e2e-nvidia-t4-x1.yml'
+    #     - check-success~=e2e-small-workflow-complete
+    #     - or:
+    #       - files~=\.py$
+    #       - files=pyproject.toml
+    #       - files~=^requirements.*\.txt$
+    #       - files=.github/workflows/e2e-nvidia-t4-x1.yml
+    #   - and:
+    #     - -files~=\.py$
+    #     - -files=pyproject.toml
+    #     - -files~=^requirements.*\.txt$
+    #     - -files=.github/workflows/e2e-nvidia-t4-x1.yml
 
     # functional gpu small workflow
     - or:

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -4,21 +4,22 @@ name: E2E (NVIDIA Tesla T4 x1)
 
 on:
   # run against every merge commit to 'main' and release branches
-  push:
-    branches:
-      - main
-      - release-*
-  # only run on PRs that touch certain regex paths
-  pull_request_target:
-    branches:
-      - main
-      - release-*
-    paths:
-      #  note this should match the merging criteria in 'mergify.yml'
-      - "**.py"
-      - "pyproject.toml"
-      - "requirements**.txt"
-      - ".github/workflows/e2e-nvidia-t4-x1.yml" # This workflow
+  workflow_dispatch:
+  # push:
+  #   branches:
+  #     - main
+  #     - release-*
+  # # only run on PRs that touch certain regex paths
+  # pull_request_target:
+  #   branches:
+  #     - main
+  #     - release-*
+  #   paths:
+  #     #  note this should match the merging criteria in 'mergify.yml'
+  #     - "**.py"
+  #     - "pyproject.toml"
+  #     - "requirements**.txt"
+  #     - ".github/workflows/e2e-nvidia-t4-x1.yml" # This workflow
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
These are consistently failing, so disable them until they are working again. This also adds a `workflow_dispatch` trigger to e2e-small, so we can test it manually to get it fixed.