### PR TITLE
Fix subset selection dynamic imports

### DIFF
--- a/src/instructlab/sdg/encoders/__init__.py
+++ b/src/instructlab/sdg/encoders/__init__.py
@@ -1,19 +1,22 @@
-# Standard
-import importlib
+# Import all encoder classes directly
+# Local
+from .arctic_encoder import ArcticEmbedEncoder
+
+# Create a mapping of encoder types to their classes
+ENCODER_REGISTRY = {
+    "arctic": ArcticEmbedEncoder,
+}
 
 
 def get_encoder_class(encoder_type: str):
     """Get the encoder class based on the encoder type."""
     try:
-        # Convert encoder_type to class name (e.g., 'arctic' -> 'ArcticEmbedEncoder')
-        class_name = f"{encoder_type.capitalize()}EmbedEncoder"
-
-        # Use absolute import instead of relative
-        module_name = f"sdg.src.instructlab.sdg.encoders.{encoder_type}_encoder"
-
-        module = importlib.import_module(module_name)
-
-        # Get the class from the module
-        return getattr(module, class_name)
-    except (ImportError, AttributeError) as e:
-        raise ValueError(f"Unsupported encoder type: '{encoder_type}'") from e
+        if encoder_type not in ENCODER_REGISTRY:
+            supported_encoders = list(ENCODER_REGISTRY.keys())
+            raise ValueError(
+                f"Unsupported encoder type: '{encoder_type}'. "
+                f"Supported types are: {supported_encoders}"
+            )
+        return ENCODER_REGISTRY[encoder_type]
+    except Exception as e:
+        raise ValueError(f"Error getting encoder class: {str(e)}") from e

--- a/src/instructlab/sdg/subset_selection.py
+++ b/src/instructlab/sdg/subset_selection.py
@@ -4,12 +4,10 @@ from multiprocessing import Pool
 from typing import Any, Dict, List, Optional, Tuple, TypedDict, TypeVar, Union
 import gc
 import glob
-import importlib
 import logging
 import math
 import os
 import re
-import sys
 
 # Third Party
 from datasets import concatenate_datasets, load_dataset
@@ -993,7 +991,6 @@ def get_supported_encoders():
         for f in encoder_files
         if not os.path.basename(f).startswith("__")
     ]
-
 
 
 def subset_datasets(

--- a/tests/test_subset_selection.py
+++ b/tests/test_subset_selection.py
@@ -123,6 +123,7 @@ def test_invalid_subset_sizes(mock_gpu_environment):
             subset_sizes=[-10],
         )
 
+
 def test_generate_embeddings_parallel(mock_gpu_environment, tmp_path, mock_encoder):
     """Test the parallelized embedding generation feature."""
     # Create a sample dataset

--- a/tests/test_subset_selection.py
+++ b/tests/test_subset_selection.py
@@ -51,7 +51,7 @@ def data_processor(mock_encoder, mock_gpu_environment):
         input_files=["test.jsonl"],
         subset_sizes=[10, 20.5],
     )
-    return DataProcessor(config, mock_encoder)
+    return DataProcessor(config)
 
 
 def test_format_text(data_processor):
@@ -123,23 +123,6 @@ def test_invalid_subset_sizes(mock_gpu_environment):
             subset_sizes=[-10],
         )
 
-
-def test_process_batch(mock_gpu_environment, data_processor, tmp_path):
-    """Test batch processing of texts"""
-
-    batch_texts = ["text1", "text2", "text3"]
-    output_file = str(tmp_path / "test_batch.h5")
-
-    embedding_dim = data_processor.process_batch(batch_texts, output_file)
-
-    assert embedding_dim is not None
-    assert os.path.exists(output_file)
-
-    with h5py.File(output_file, "r") as f:
-        embeddings = f["embeddings"][:]
-        assert embeddings.shape == (3, embedding_dim)
-
-
 def test_generate_embeddings_parallel(mock_gpu_environment, tmp_path, mock_encoder):
     """Test the parallelized embedding generation feature."""
     # Create a sample dataset
@@ -165,7 +148,7 @@ def test_generate_embeddings_parallel(mock_gpu_environment, tmp_path, mock_encod
     config.system.num_gpus = 2
 
     # Create processor
-    processor = DataProcessor(config, mock_encoder)
+    processor = DataProcessor(config)
 
     # Test case 1: File exists, should return early
     result_path = processor.generate_embeddings(dataset, output_dir)


### PR DESCRIPTION
Refactor DataProcessor to use centralized encoder class retrieval

- Removed the encoder class initialization from the DataProcessor constructor.
- Introduced a centralized method for obtaining encoder classes in the encoders module (addressed messy sys path / dynamic imports).
- Updated relevant tests to reflect the changes in DataProcessor initialization.
- Cleaned up unused imports and code related to dynamic encoder imports.