### PR TITLE
Test to ensure we don't mix chunks across calls to DocumentChunker

### DIFF
--- a/tests/functional/test_chunkers.py
+++ b/tests/functional/test_chunkers.py
@@ -147,3 +147,38 @@ def test_chunk_documents(
         assert (
             overlap_count / (len(chunks) - 1) >= 0.3
         ), "Insufficient overlap between consecutive chunks"
+
+
+def test_chunk_documents_chunks_not_mixing(tmp_path, tokenizer_model_name):
+    """
+    Ensure chunks are not mixing together across multiple
+    instances of DocumentChunker even if they are passed the same
+    output directory
+    """
+    doc_path_1 = os.path.join(TEST_DATA_DIR, "sample_documents", "phoenix.md")
+    doc_path_2 = os.path.join(TEST_DATA_DIR, "sample_documents", "moo_deng.md")
+
+    output = os.path.join(tmp_path, "output")
+    os.makedirs(output, exist_ok=True)
+
+    chunker_1 = DocumentChunker(
+        document_paths=[Path(doc_path_1)],
+        output_dir=output,
+        tokenizer_model_name=tokenizer_model_name,
+        server_ctx_size=4096,
+        chunk_word_count=500,
+    )
+    chunks_1 = " ".join(chunker_1.chunk_documents())
+    assert "Phoenix" in chunks_1
+    assert "Moo Deng" not in chunks_1
+
+    chunker_2 = DocumentChunker(
+        document_paths=[Path(doc_path_2)],
+        output_dir=output,
+        tokenizer_model_name=tokenizer_model_name,
+        server_ctx_size=4096,
+        chunk_word_count=500,
+    )
+    chunks_2 = " ".join(chunker_2.chunk_documents())
+    assert "Moo Deng" in chunks_2
+    assert "Phoenix" not in chunks_2

--- a/tests/testdata/sample_documents/moo_deng.md
+++ b/tests/testdata/sample_documents/moo_deng.md
@@ -1,0 +1,93 @@
+<!-- image -->
+
+## Moo Deng
+
+Moo  Deng (born 10 July 2024) is a pygmy hippopotamus living in Khao Kheow Open Zoo in Si Racha, Chonburi, Thailand. [1][2] She became a popular  Internet  meme  at  two  months  of  age  after images of her went viral online in September 2024.
+
+## Background
+
+Moo Deng was born on 10 July 2024 to parents Tony and Jonah. She has two full siblings (Nadet and Moo Tun)  and  four  half-siblings  (Ko,  Kanya,  Phalo,  and Moo  Wan). [3]   The  name Moo  Deng (Thai: ห"เ$ง , RTGS: mu  deng,  pronounced  [m ǔ ː dGLYPH&lt;144&gt; ŋ ]  )  was  chosen through  a  public  poll, with  over  20,000  people voting for it. It translates to 'bouncy pork' or 'bouncy pig' in English. [4][5][6][7]
+
+## Online popularity
+
+Khao Kheow Open Zoo posted images of its pygmy hippopotamuses  on  its  official  Facebook  page,  and
+
+## Moo Deng ห"เ$ง
+
+Moo Deng in 2024
+
+<!-- image -->
+
+Species
+
+Pygmy hippopotamus ( Choeropsis liberiensis )
+
+Sex
+
+Female
+
+Born
+
+10 July 2024
+
+Residence
+
+Khao Kheow Open Zoo, Si Racha, Chonburi, Thailand
+
+Parent(s)
+
+Jonah (mother) and Tony (father)
+
+Named after
+
+Thai for 'bouncy pork' or 'bouncy pig'
+
+Moo Deng quickly became a favorite among fans. [8]  Moo Deng is noted to be more playful and energetic than other hippopotamuses. In response to her popularity, the zoo began selling clothing and other merchandise featuring designs based on  Moo  Deng. [4][9][10] Moo  Deng  has  become  the  subject  of many pieces of fan art. [11]
+
+<!-- image -->
+
+Due to Moo Deng's viral online popularity, the number of daily visitors  to  the  zoo  doubled  in  early  September  2024. [12][13] Around  this  time,  some  visitors  have  harassed  the  baby  by
+
+Thai-language news coverage of Moo Deng in September 2024
+
+splashing  her  with  water [10][14] or  throwing  objects  at  her  to wake her up. As a result, the Khao Kheow Open Zoo installed security  cameras  around  her  enclosure.  The  zoo  director  has threatened legal action against visitors who harassed her. [15][16] [14] The misbehavior by some visitors has been widely condemned  online. [17][18] The  zoo  also  implemented  a  fiveminute time limit for visitors in order to accommodate the high volume. [19]
+
+<!-- image -->
+
+In September 2024, zoo director Narongwit Chodchoi announced that the zoo had begun the process of copyrighting and trademarking "Moo Deng the hippo" to raise funds for the zoo. [6][20] The zoo also plans to launch a continuous livestream to allow fans to watch Moo Deng live over the Internet. [21]
+
+A cut-out depicting Moo Deng at Book Expo Thailand 2024 in October
+
+On  September  28,  Moo  Deng  was  the  subject  of  a Saturday  Night  Live sketch. [22] She  was parodied by Bowen Yang on Weekend Update, and  the  character  was  used  to  satirize  American pop-artist Chappell Roan's commentary on fame and political endorsements. [23]
+
+## Welfare concerns
+
+Animal welfare groups have expressed concern for Moo Deng. A spokesperson for People for the Ethical  Treatment  of  Animals  said,  "She  faces  a  lifetime  of  confinement,"  while  World  Animal Protection  said,  "Sharing  Moo  Deng  content  might  seem  innocuous,  but  it  promotes  cruelty  to animals." [24] The zoo's director, Narongwit Chodchoi, rejected the allegations and maintained that the facility ensures the welfare and quality of life for more than 2,000 animals. [24] The Thai Society for the Prevention of Cruelty to Animals said that Moo Deng was well taken care of and that PETA was relying on "outdated" information. [24]
+
+## See also
+
+- Hua Hua, a baby panda that gained online popularity in 2024
+- Knut, a baby polar bear that gained online popularity
+- Pesto, a baby penguin that gained online popularity in September 2024
+- Fiona, another hippo that gained online popularity
+
+## References
+
+1.  "Zoos in Thailand - Khao Kheow Open Zoo" (http://www.sawadee.com/thailand/zoo/kkzoo.htm
+
+- 1.  "Zoos in Thailand - Khao Kheow Open Zoo" (http://www.sawadee.com/thailand/zoo/kkzoo.htm l). sawadee.com . Archived (https://web.archive.org/web/20161023124601/http://www.sawadee. com/thailand/zoo/kkzoo.html) from the original on 23 October 2016. Retrieved 19 October 2016.
+- 2.  "Khao Kheow Open Zoo - Attractions in Pattaya" (http://www.pattayaconcierge.com/specified-pl ace/khao-kheow-open-zoo/200800000116/attraction/). pattayaconcierge.com . Archived (https:// web.archive.org/web/20161117063125/http://www.pattayaconcierge.com/specified-place/khaokheow-open-zoo/200800000116/attraction/) from the original on 17 November 2016. Retrieved 19 October 2016.
+- 3.  " &amp;บญา* +องห"เ$ง " " -ว/งสวน2ต4เ5ดเขาเ8ยว " (https://mgronline.com/local/detail/96700000899 41). Manager Online (in Thai). 25 September 2024. Archived (https://archive.today/202410011 30055/https://mgronline.com/local/detail/9670000089941) from the original on 1 October 2024.
+- 4.  "Pygmy hippo calf captures hearts at Khao Kheow Open Zoo; fans show interests in pants" (htt ps://www.pattayamail.com/latestnews/news/pygmy-hippo-calf-captures-hearts-at-khao-kheow-o pen-zoo-fans-show-interests-in-pants-471760). Pattaya Mail . 25 July 2024. Archived (https://we b.archive.org/web/20240924180218/https://www.pattayamail.com/latestnews/news/pygmy-hipp o-calf-captures-hearts-at-khao-kheow-open-zoo-fans-show-interests-in-pants-471760) from the original on 24 September 2024. Retrieved 25 September 2024.
+- 5.  Duster, Chandelis (18 September 2024). "Meet Moo Deng, the baby pygmy hippo so popular you can visit her for only 5 minutes" (https://www.npr.org/2024/09/18/nx-s1-5115841/meet-moodeng-baby-pygmy-hippo). NPR. Archived (https://web.archive.org/web/20240923120845/http s://www.npr.org/2024/09/18/nx-s1-5115841/meet-moo-deng-baby-pygmy-hippo) from the original on 23 September 2024. Retrieved 24 September 2024.
+- 6.  Saksornchai, Jintamas (19 September 2024). "Thailand's adorable pygmy hippo Moo Deng has the kind of face that launches a thousand memes" (https://apnews.com/article/moo-deng-babyhippo-thailand-zoo-27485f0cbc70071252be45d870d507aa). Associated Press . Archived (http s://web.archive.org/web/20240926001231/https://apnews.com/article/moo-deng-baby-hippo-th ailand-zoo-27485f0cbc70071252be45d870d507aa) from the original on 26 September 2024. Retrieved 25 September 2024.
+- 7.  " ห" " (https://www.thai2english.com/?q=1414519). Thai2english.com . Archived (https://archive. ph/UehYL) from the original on 21 October 2024.
+- " เ$ง " (https://www.thai2english.com/?q=1308072). Thai2english.com . Archived (https://archive. ph/vDCz6) from the original on 21 October 2024.
+- 8.  Tiengtae, Nannalin (11 September 2024). "Baby pygmy hippo the star at Chon Buri zoo" (http s://www.bangkokpost.com/thailand/general/2863668/baby-pygmy-hippo-the-star-at-chon-buri-z oo). Bangkok Post . Archived (https://web.archive.org/web/20241001141819/https://www.bangk okpost.com/thailand/general/2863668/baby-pygmy-hippo-the-star-at-chon-buri-zoo) from the original on 1 October 2024. Retrieved 12 September 2024.
+- 9.  "Viral Pygmy Hippo 'Moo Deng' Boosts Khao Kheow Open Zoo Visitors" (https://www.khaosode nglish.com/tourism/2024/09/12/viral-pygmy-hippo-moo-deng-boosts-khao-kheow-open-zoo-visi tors/). Khaosod English . 12 September 2024. Archived (https://web.archive.org/web/20240912 234020/https://www.khaosodenglish.com/tourism/2024/09/12/viral-pygmy-hippo-moo-deng-boo sts-khao-kheow-open-zoo-visitors/) from the original on 12 September 2024. Retrieved 12 September 2024.
+
+10.
+
+Baby Hippo named Moo becomes viral sensation
+
+(https://www.nbcnews.com/now/video/baby-h


### PR DESCRIPTION
This adds a new functional test to verify that if we call DocumentChunker multiple times with different sets of documents that we are not mixing chunks across each of those calls, even if the same output_dir parameter is passed into each call of DocumentChunker.

We had an issue with this in the v0.7.x releases, but this test verifies this is no longer an issue in main.