### PR TITLE
deps: Bump minimum required Python version to 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.10"
           - "3.11"
           - "3.12"
         platform:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 description = "Synthetic Data Generation"
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
@@ -22,7 +22,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -91,7 +90,7 @@ from-first = true
 known-local-folder = ["tuning"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 disable_error_code = ["import-not-found", "import-untyped"]
 exclude = [
     "^src/instructlab/sdg/generate_data\\.py$",

--- a/tox.ini
+++ b/tox.ini
@@ -95,4 +95,3 @@ commands =
 python =
     3.12 = py312-{unitcov, functional}
     3.11 = py311-{unitcov, functional}
-    3.10 = py310-{unitcov, functional}


### PR DESCRIPTION
## Overview

In our core repo, we require Python >=3.11: https://github.com/instructlab/instructlab/blob/main/pyproject.toml#L13

In this repo, however, we currently require Python >=3.10. Therefore, we should ensure consistency in terms of Python version support throughout our GitHub org.

## Proposed Changes
This bump includes updates to documentation, Git workflows, test configs, etc.