### PR TITLE
chore: Pin release-v0.8 releases to release-v0.26 of instructlab

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -89,6 +89,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "instructlab/instructlab"
+          ref: "release-v0.26"
           path: "instructlab"
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -67,6 +67,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "instructlab/instructlab"
+          ref: "release-v0.26"
           path: "instructlab"
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -90,6 +90,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "instructlab/instructlab"
+          ref: "release-v0.26"
           path: "instructlab"
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0


### PR DESCRIPTION
This ensures our CI for the release-v0.8 branch runs against the corresponding release branch of instructlab/instructlab, instead of against the main branch.

See a successful test run of this on another branch at https://github.com/instructlab/sdg/actions/runs/15055414214/job/42322637107