### PR TITLE
ci: preserve e2e test directory at the end of each run

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -141,7 +141,7 @@ jobs:
         working-directory: ./instructlab
         run: |
           . venv/bin/activate
-          ./scripts/e2e-ci.sh -m
+          ./scripts/e2e-ci.sh -m -p
 
       - name: Check disk after tests
         run: |

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -194,7 +194,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           . venv/bin/activate
-          ./scripts/e2e-ci.sh -l
+          ./scripts/e2e-ci.sh -l -p
 
       - name: Check disk after tests
         run: |

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -139,7 +139,7 @@ jobs:
         working-directory: ./instructlab
         run: |
           . venv/bin/activate
-          ./scripts/e2e-ci.sh -s
+          ./scripts/e2e-ci.sh -s -p
 
       - name: Check disk after tests
         run: |


### PR DESCRIPTION
Prior to this change, the `e2e-ci.sh` script would always delete `$E2E_TEST_DIR` at the end of every run.

Add `-p` for the reasons described in #640 :

- Efficiency: We don't waste time running `rm -rf` on many files in a volume that we will terminate in AWS moments later
- Consistency: Our instructlab core e2e jobs all use the `-p` flag already
- Clarity: When we run `df -h` at the end of our e2e jobs, we want to see how much space the test used, particularly for troubleshooting `ENOSPC` issues.

Fixes: #640 