### PR TITLE
ci: report inode utilization

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -136,6 +136,7 @@ jobs:
       - name: Check disk before tests
         run: |
           df -h
+          df -i
   
       - name: Run e2e test
         working-directory: ./instructlab
@@ -146,6 +147,7 @@ jobs:
       - name: Check disk after tests
         run: |
           df -h
+          df -i
 
   stop-medium-ec2-runner:
     needs:

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -186,6 +186,7 @@ jobs:
       - name: Check disk before tests
         run: |
           df -h
+          df -i
 
       - name: Run e2e test
         working-directory: ./instructlab
@@ -199,6 +200,7 @@ jobs:
       - name: Check disk after tests
         run: |
           df -h
+          df -i
 
       - name: Add comment to PR if the workflow failed
         if: failure() && steps.check_pr.outputs.is_pr == 'true'

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Check disk before tests
         run: |
           df -h
+          df -i
 
       - name: Run e2e test
         working-directory: ./instructlab
@@ -144,6 +145,7 @@ jobs:
       - name: Check disk after tests
         run: |
           df -h
+          df -i
 
   stop-small-ec2-runner:
     needs:

--- a/.github/workflows/functional-gpu-nvidia-t4-x1.yml
+++ b/.github/workflows/functional-gpu-nvidia-t4-x1.yml
@@ -111,6 +111,7 @@ jobs:
       - name: Check disk before tests
         run: |
           df -h
+          df -i
 
       - name: Run functional gpu tests with tox
         run: |
@@ -120,6 +121,7 @@ jobs:
       - name: Check disk after tests
         run: |
           df -h
+          df -i
 
   stop-small-ec2-runner:
     needs:


### PR DESCRIPTION
This is a total shot in the dark to get more data on https://github.com/instructlab/instructlab/issues/3298

Occasionally we hit `ENOSPC` errors from numpy. Theoretically inode exhaustion is one possible cause of `ENOSPC`. Report the number of inodes before and after the tests.

I recommend merging https://github.com/instructlab/sdg/pull/641 prior to this PR. When we do not run `e2e-ci.sh` with `-p`, that can throw off our `df` accounting.