### PR TITLE
add DCO.txt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,3 +105,7 @@ request. If you're unfamiliar with how to submit a pull request, the
 GitHub documentation on [Collaborating with pull
 requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests)
 is a good guide to follow.
+
+## Developer Certificate of Origin
+
+When you make a contribution to InstructLab SDG, you implicitly agree to the Developer Certificate of Origin terms as set in `DCO.txt` at the root of this repository.

--- a/DCO.txt
+++ b/DCO.txt
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
Add the contents of https://developercertificate.org/ to `DCO.txt` at the root of this repository.

Explain to contributors that new submissions imply acceptance of the DCO.