### PR TITLE
ci: do not require DCO job

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,7 +8,6 @@ pull_request_rules:
     - label!=hold
     - label!=do-not-merge
     - label!=needs-rebase
-    - check-success=DCO
 
     - or:
       # base branch is main or a release branch


### PR DESCRIPTION
We are going to disable this job for this repository and rely on contributors' implicit acceptance of `DCO.txt` instead.

Related: https://github.com/instructlab/dev-docs/pull/192