### PR TITLE
ci: always display disk statistics

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -159,6 +159,7 @@ jobs:
           ./scripts/e2e-ci.sh -m -p
 
       - name: Check disk after tests
+        if: ${{ always() }}
         run: |
           df -h
           df -i

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -211,6 +211,7 @@ jobs:
           ./scripts/e2e-ci.sh -l -p
 
       - name: Check disk after tests
+        if: ${{ always() }}
         run: |
           df -h
           df -i

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -146,6 +146,7 @@ jobs:
           ./scripts/e2e-ci.sh -s -p
 
       - name: Check disk after tests
+        if: ${{ always() }}
         run: |
           df -h
           df -i

--- a/.github/workflows/functional-gpu-nvidia-t4-x1.yml
+++ b/.github/workflows/functional-gpu-nvidia-t4-x1.yml
@@ -120,6 +120,7 @@ jobs:
           tox -e functional-gpu
 
       - name: Check disk after tests
+        if: ${{ always() }}
         run: |
           df -h
           df -i


### PR DESCRIPTION
Prior to this change, if the e2e integration tests failed ([example](https://github.com/instructlab/sdg/actions/runs/15444001454/job/43468847402)), we would not display the output from `df`, so we could not learn the debugging information about the state of the disks.
