### PR TITLE
Update to v0.2.1 of instructlab/ci-actions

### DIFF
--- a/.github/workflows/constraints-update.yml
+++ b/.github/workflows/constraints-update.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           repository: instructlab/ci-actions
           path: ci-actions
-          ref: v0.2.0
+          ref: v0.2.1
           sparse-checkout: |
             actions/update-constraints
 


### PR DESCRIPTION
This version uses `uv pip compile`, which we want.