### PR TITLE
Remove torch/vllm from constraints-dev.txt.in

### DIFF
--- a/constraints-dev.txt.in
+++ b/constraints-dev.txt.in
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# These are synchronized with instructlab repo; we have to keep them in sync at
-# least until we no longer tie sdg repo CI with ilab repo through e2e jobs.
-torch<2.7.0
-vllm<0.9.0
+# SDG has no specific dev version constraints at this point - if we need to
+# explicitly cap versions in the future, do it here.


### PR DESCRIPTION
SDG doesn't actually use those libraries directly, so we don't need to list them there.