### PR TITLE
functional-gpu job: missed converting "ec2-instance-type" to "ec2_instance_type"

### DIFF
--- a/.github/workflows/functional-gpu-nvidia-t4-x1.yml
+++ b/.github/workflows/functional-gpu-nvidia-t4-x1.yml
@@ -92,8 +92,8 @@ jobs:
               }
             ]
           try_spot_instance_first: false
-          ec2-instance-type: g4dn.2xlarge
-          aws-resource-tags: >
+          ec2_instance_type: g4dn.2xlarge
+          aws_resource_tags: >
             [
               {"Key": "Name", "Value": "instructlab-ci-github-small-runner"},
               {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},


### PR DESCRIPTION
Manually kicked off a version of this at https://github.com/instructlab/sdg/actions/runs/15561669455 and it passed. The last change here forgot to update these hyphens to underscores.