### PR TITLE
Actually test against release branches of SDG and InstructLab

### DIFF
--- a/.github/workflows/e2e-nvidia-l40s-x4-release.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4-release.yml
@@ -5,15 +5,12 @@ name: E2E (NVIDIA L40S x4) Release Branch
 on:
   schedule:
     - cron: '0 19 * * 1,3' # Runs at 7PM UTC every Mon/Wed
-  workflow_dispatch:
-    inputs:
-      pr_or_branch:
-        description: 'pull request number or branch name'
-        required: true
-        default: 'release-v0.8'
+  workflow_dispatch: {}
 
 env:
   TMPDIR: /home/tmp
+  LATEST_SDG_RELEASE_BRANCH: release-v0.8
+  LATEST_ILAB_RELEASE_BRANCH: release-v0.26
 
 jobs:
   start-large-ec2-runner:
@@ -98,6 +95,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "instructlab/instructlab"
+          ref: ${{ env.LATEST_ILAB_RELEASE_BRANCH }}
           path: "instructlab"
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
@@ -106,70 +104,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: "sdg"
+          ref: ${{ env.LATEST_SDG_RELEASE_BRANCH }}
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
-
-      - name: Determine if pr_or_branch is a PR number
-        id: check_pr
-        run: |
-          PR_OR_BRANCH=${{ github.event.inputs.pr_or_branch || 'main' }} # Default to 'main' if not set
-          if [[ "$PR_OR_BRANCH" =~ ^[0-9]+$ ]]; then
-            echo "is_pr=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_pr=false" >> "$GITHUB_OUTPUT"
-          fi
-          echo "pr_or_branch=$PR_OR_BRANCH" >> "$GITHUB_OUTPUT"
-
-      - name: Check if gh cli is installed
-        id: gh_cli
-        run: |
-          if command -v gh &> /dev/null ; then
-            echo "gh_cli_installed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "gh_cli_installed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Install gh CLI
-        if: steps.gh_cli.outputs.gh_cli_installed == 'false'
-        run: |
-          sudo dnf install 'dnf-command(config-manager)' -y
-          sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-          sudo dnf install gh --repo gh-cli -y
-
-      - name: test gh CLI
-        run: |
-          gh --version
-
-      - name: set default repo
-        working-directory: ./sdg
-        run: |
-          gh repo set-default ${{ github.server_url }}/${{ github.repository }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Add comment to PR
-        if: steps.check_pr.outputs.is_pr == 'true'
-        working-directory: ./sdg
-        run: |
-          gh pr comment "${{ steps.check_pr.outputs.pr_or_branch }}" -b "${{ github.workflow }} workflow launched on this PR: [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Fetch and checkout PR
-        if: steps.check_pr.outputs.is_pr == 'true'
-        working-directory: ./sdg
-        run: |
-          git fetch origin pull/${{ steps.check_pr.outputs.pr_or_branch }}/merge:pr-merge-${{ steps.check_pr.outputs.pr_or_branch }}
-          git checkout pr-merge-${{ steps.check_pr.outputs.pr_or_branch }}
-          git log -1 --format="%H %s"
-
-      - name: Checkout branch
-        if: steps.check_pr.outputs.is_pr == 'false'
-        working-directory: ./sdg
-        run: |
-          git checkout ${{ steps.check_pr.outputs.pr_or_branch }}
-          git log -1 --format="%H %s"
-
 
       - name: Install ilab
         working-directory: ./instructlab
@@ -216,43 +153,27 @@ jobs:
           df -h
           df -i
 
-      - name: Add comment to PR if the workflow failed
-        if: failure() && steps.check_pr.outputs.is_pr == 'true'
-        working-directory: ./sdg
-        run: |
-          gh pr comment "${{ steps.check_pr.outputs.pr_or_branch }}" -b "e2e workflow failed on this PR: [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}), please investigate."
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Add comment to PR if the workflow succeeded
-        if: success() && steps.check_pr.outputs.is_pr == 'true'
-        working-directory: ./sdg
-        run: |
-          gh pr comment "${{ steps.check_pr.outputs.pr_or_branch }}" -b "e2e workflow succeeded on this PR: [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}), congrats!"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Send Discord notification for failure
-        if: failure() && steps.check_pr.outputs.is_pr == 'false'
+        if: failure()
         uses: sarisia/actions-status-discord@5ddd3b114a98457dd80a39b2f00b6a998cd69008 # v1.15.3
         with:
           webhook: ${{ secrets.SON_OF_JEEVES_DISCORD_WEBHOOK }}
           status: ${{ job.status }}
           title: "e2e-nvidia-l40s-x4"
           description: |
-            Job in **${{ github.repository }}** running on branch `${{ steps.check_pr.outputs.pr_or_branch }}` completed **with failures** ❌
+            Job in **${{ github.repository }}** running on branch `${{ env.LATEST_SDG_RELEASE_BRANCH }}` completed **with failures** ❌
             Click [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) to view details.
           color: 0xCB2431 # Red color for failure
 
       - name: Send Discord notification for success
-        if: success() && steps.check_pr.outputs.is_pr == 'false'
+        if: success()
         uses: sarisia/actions-status-discord@5ddd3b114a98457dd80a39b2f00b6a998cd69008 # v1.15.3
         with:
           webhook: ${{ secrets.SON_OF_JEEVES_DISCORD_WEBHOOK }}
           status: ${{ job.status }}
           title: "e2e-nvidia-l40s-x4"
           description: |
-            Job in **${{ github.repository }}** running on branch `${{ steps.check_pr.outputs.pr_or_branch }}` completed **successfully** ✅
+            Job in **${{ github.repository }}** running on branch `${{ env.LATEST_SDG_RELEASE_BRANCH }}` completed **successfully** ✅
             Click [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) to view details.
           color: 0x28A745 # Green color for success
 


### PR DESCRIPTION
The scheduled job was running against SDG main branch (because the default from the `workflow_dispatch` only applies when manually run) and it was cloning instructlab/instructlab main instead of its release branch. This fixes that.