### PR TITLE
Disable constraints update on main

### DIFF
--- a/.github/workflows/constraints-update.yml
+++ b/.github/workflows/constraints-update.yml
@@ -1,8 +1,8 @@
 name: Update constraints-dev.txt
 
 on:
-  schedule:
-    - cron: '0 3 * * 1'  # Every Monday at 03:00 UTC
+  # schedule:
+  #   - cron: '0 3 * * 1'  # Every Monday at 03:00 UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We don't need to keep bumping these constraints on main, and can instead bump them on-demand with this job any time it's needed if it is needed. We're more likely to need to update these on our release branches anyway.